### PR TITLE
Update API settings to use single global Firestore path

### DIFF
--- a/src/app/api/settings/route.js
+++ b/src/app/api/settings/route.js
@@ -9,13 +9,9 @@ import { doc, getDoc, setDoc, serverTimestamp } from 'firebase/firestore';
 export async function GET(request) {
   try {
     const { searchParams } = new URL(request.url);
-    const uid = searchParams.get('uid');
+    const uid = searchParams.get('uid') || 'owner';
 
-    if (!uid) {
-      return NextResponse.json({ error: 'uid required' }, { status: 400 });
-    }
-
-    const docRef = doc(db, 'users', uid, 'config', 'settings');
+    const docRef = doc(db, 'settings', 'user_preferences');
     const snap = await getDoc(docRef);
 
     if (!snap.exists()) {
@@ -56,16 +52,16 @@ export async function GET(request) {
  */
 export async function POST(request) {
   try {
-    const { uid, settings } = await request.json();
+    const { uid = 'owner', settings } = await request.json();
 
-    if (!uid || !settings) {
+    if (!settings) {
       return NextResponse.json(
-        { error: 'uid and settings required' },
+        { error: 'settings required' },
         { status: 400 }
       );
     }
 
-    const docRef = doc(db, 'users', uid, 'config', 'settings');
+    const docRef = doc(db, 'settings', 'user_preferences');
     await setDoc(docRef, {
       ...settings,
       updatedAt: serverTimestamp(),


### PR DESCRIPTION
Update the Firestore settings path to be a global user_preferences document since this is a single-user application. Made \`uid\` optional and defaulted it to "owner" in the API routes.

---
*PR created automatically by Jules for task [13779348888552787234](https://jules.google.com/task/13779348888552787234) started by @JClouddd*