### PR TITLE
Add security hardening guide and helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ Create a `.env.local` file in the root directory and configure the following var
 
 ---
 
+## 🔒 Security
+
+For detailed instructions on securing your Gravix installation, including setting up GCP Service Accounts and restricting API keys, please refer to the [Security Setup Guide](docs/SECURITY_SETUP.md).
+
+---
+
 ## 📄 License
 
 This project is licensed under the **MIT License**.

--- a/docs/SECURITY_SETUP.md
+++ b/docs/SECURITY_SETUP.md
@@ -1,0 +1,98 @@
+# Gravix Security Setup
+
+This document provides step-by-step instructions for securing your Gravix installation. It covers setting up a service account for GCP integrations and restricting your Gemini API key to prevent unauthorized usage.
+
+## 1. Create a GCP Service Account
+
+Gravix requires a Google Cloud Platform Service Account (`gravix-hub-sa`) to access Vertex AI, Firestore, Storage, Secret Manager, Cloud Scheduler, and Dialogflow securely.
+
+### Step-by-Step Instructions
+
+**Prerequisites:** Ensure you have the `gcloud` CLI installed and authenticated with your target GCP project.
+
+1. **Set your Project ID**
+   ```bash
+   export PROJECT_ID="your-gcp-project-id"
+   gcloud config set project $PROJECT_ID
+   ```
+
+2. **Create the Service Account**
+   ```bash
+   gcloud iam service-accounts create gravix-hub-sa \
+       --display-name="Gravix Hub Service Account"
+   ```
+
+3. **Assign Necessary Roles**
+   Assign the following roles to the newly created service account:
+   - Vertex AI User (`roles/aiplatform.user`)
+   - Firestore User (`roles/datastore.user`)
+   - Storage Object Viewer (`roles/storage.objectViewer`)
+   - Secret Manager Secret Accessor (`roles/secretmanager.secretAccessor`)
+   - Cloud Scheduler Job Runner (`roles/cloudscheduler.jobRunner`)
+   - Dialogflow API Client (`roles/dialogflow.client`)
+
+   Use the following command for each role, replacing `[ROLE]` with the role name above:
+   ```bash
+   export SA_EMAIL="gravix-hub-sa@$PROJECT_ID.iam.gserviceaccount.com"
+
+   gcloud projects add-iam-policy-binding $PROJECT_ID \
+       --member="serviceAccount:$SA_EMAIL" \
+       --role="[ROLE]"
+   ```
+   *(Alternatively, use the `scripts/setup-service-account.sh` script to automate this process).*
+
+4. **Generate and Download the Key**
+   ```bash
+   gcloud iam service-accounts keys create gravix-hub-sa-key.json \
+       --iam-account=$SA_EMAIL
+   ```
+   **Important:** Keep this `gravix-hub-sa-key.json` file secure. Do not commit it to version control.
+
+## 2. Restrict Your Gemini API Key
+
+To prevent unauthorized access and usage of your Gemini API key, it is highly recommended to restrict its usage to specific domains.
+
+### Instructions
+
+You can restrict your API key using the Google Cloud Console or via the provided script.
+
+**Using the `scripts/restrict-api-key.sh` script:**
+1. Ensure your `gcloud` CLI is configured.
+2. Run the script:
+   ```bash
+   ./scripts/restrict-api-key.sh "your-api-key-id"
+   ```
+   *Note: This restricts the key to `gravix-eight.vercel.app/*` and `localhost:3000/*` and limits usage to the `generativelanguage.googleapis.com` API.*
+
+**Manual Configuration (Google Cloud Console):**
+1. Navigate to **APIs & Services > Credentials**.
+2. Click on your Gemini API key.
+3. Under **Application restrictions**, select **HTTP referrers (web sites)**.
+4. Add the following website restrictions:
+   - `gravix-eight.vercel.app/*`
+   - `http://localhost:3000/*`
+5. Under **API restrictions**, select **Restrict key**.
+6. Select **Generative Language API** (`generativelanguage.googleapis.com`) from the dropdown.
+7. Click **Save**.
+
+## 3. Set Up Vercel Environment Variables
+
+Once you have your service account key and restricted API key, configure them in your Vercel deployment.
+
+1. Go to your Gravix project in the Vercel dashboard.
+2. Navigate to **Settings > Environment Variables**.
+3. Add your standard environment variables (e.g., `GEMINI_API_KEY`).
+4. To add the Service Account Key:
+   - Open your `gravix-hub-sa-key.json` file.
+   - You can either stringify the JSON and store it in a single variable (e.g., `GOOGLE_APPLICATION_CREDENTIALS_JSON`) or store specific fields like `GCP_PROJECT_ID`, `GCP_CLIENT_EMAIL`, and `GCP_PRIVATE_KEY` depending on your application's setup.
+   *(Gravix uses default Google auth, so providing the stringified JSON or base64 encoded JSON is common practice for Vercel, typically parsed during initialization).*
+
+## Security Checklist
+
+- [ ] `gravix-hub-sa` service account created.
+- [ ] Required IAM roles assigned to `gravix-hub-sa`.
+- [ ] Service account JSON key generated and downloaded securely.
+- [ ] Gemini API key restricted to `gravix-eight.vercel.app` and `localhost:3000`.
+- [ ] Gemini API key restricted to `generativelanguage.googleapis.com` API.
+- [ ] Vercel environment variables securely configured.
+- [ ] `gravix-hub-sa-key.json` added to `.gitignore` (if present locally).

--- a/scripts/restrict-api-key.sh
+++ b/scripts/restrict-api-key.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <API_KEY_ID>"
+  echo "You can find your API Key ID using: gcloud services api-keys list"
+  exit 1
+fi
+
+API_KEY_ID=$1
+PROJECT_ID=$(gcloud config get-value project)
+
+echo "======================================================"
+echo " Restricting Gemini API Key"
+echo "======================================================"
+echo "Project ID: $PROJECT_ID"
+echo "API Key ID: $API_KEY_ID"
+echo "======================================================"
+echo ""
+
+echo "Updating API key restrictions..."
+
+gcloud services api-keys update "$API_KEY_ID" \
+    --allowed-referrers="https://gravix-eight.vercel.app/*,http://localhost:3000/*" \
+    --api-targets="generativelanguage.googleapis.com"
+
+echo ""
+echo "======================================================"
+echo " Restriction Complete!"
+echo "======================================================"
+echo "Your API key is now restricted to:"
+echo " - Referrers: gravix-eight.vercel.app/* and localhost:3000/*"
+echo " - API: generativelanguage.googleapis.com"
+echo "======================================================"

--- a/scripts/setup-service-account.sh
+++ b/scripts/setup-service-account.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Setup variables
+PROJECT_ID=$(gcloud config get-value project)
+SA_NAME="gravix-hub-sa"
+SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+KEY_FILE="${SA_NAME}-key.json"
+
+echo "======================================================"
+echo " Setting up Gravix Service Account for GCP"
+echo "======================================================"
+echo "Project ID: $PROJECT_ID"
+echo "Service Account Name: $SA_NAME"
+echo "Service Account Email: $SA_EMAIL"
+echo "======================================================"
+echo ""
+
+# 1. Create the Service Account
+echo "Creating service account..."
+if gcloud iam service-accounts list --filter="email:${SA_EMAIL}" | grep -q "${SA_EMAIL}"; then
+  echo "Service account already exists."
+else
+  gcloud iam service-accounts create ${SA_NAME} \
+      --display-name="Gravix Hub Service Account"
+  echo "Service account created."
+fi
+echo ""
+
+# 2. Assign Roles
+echo "Assigning IAM roles..."
+
+ROLES=(
+  "roles/aiplatform.user"
+  "roles/datastore.user"
+  "roles/storage.objectViewer"
+  "roles/secretmanager.secretAccessor"
+  "roles/cloudscheduler.jobRunner"
+  "roles/dialogflow.client"
+)
+
+for ROLE in "${ROLES[@]}"; do
+  echo "Assigning $ROLE..."
+  gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+      --member="serviceAccount:${SA_EMAIL}" \
+      --role="${ROLE}" \
+      --condition=None > /dev/null
+done
+echo "Roles assigned successfully."
+echo ""
+
+# 3. Generate JSON Key
+echo "Generating JSON key..."
+if [ -f "$KEY_FILE" ]; then
+  echo "Key file $KEY_FILE already exists. Skipping key generation."
+else
+  gcloud iam service-accounts keys create ${KEY_FILE} \
+      --iam-account=${SA_EMAIL}
+  echo "Key generated and saved to $KEY_FILE."
+fi
+
+echo ""
+echo "======================================================"
+echo " Setup Complete!"
+echo "======================================================"
+echo "IMPORTANT: The key file '$KEY_FILE' contains sensitive information."
+echo "Keep it secure and DO NOT commit it to version control."
+echo ""
+echo "Next Steps for Vercel Deployment:"
+echo "1. Open $KEY_FILE in a text editor."
+echo "2. Copy its entire contents."
+echo "3. Go to your Vercel Project > Settings > Environment Variables."
+echo "4. Add an environment variable (e.g., GOOGLE_APPLICATION_CREDENTIALS_JSON) and paste the contents as the value."
+echo "   (Consult the Vercel documentation or Gravix setup guide for the exact variable name expected by your application logic)."
+echo "======================================================"


### PR DESCRIPTION
This PR adds documentation and helper bash scripts to secure a Gravix installation.
- **`docs/SECURITY_SETUP.md`**: Provides step-by-step instructions for creating the `gravix-hub-sa` service account, generating keys, and restricting the Gemini API key.
- **`scripts/setup-service-account.sh`**: Automates creating the service account, assigning roles (Vertex AI User, Firestore User, Storage Object Viewer, Secret Manager Secret Accessor, Cloud Scheduler Job Runner, Dialogflow API Client), and generating the JSON key.
- **`scripts/restrict-api-key.sh`**: Automates applying HTTP referrer and API target restrictions to the Gemini API key via the `gcloud` CLI.
- Both scripts are executable.
- The `README.md` is updated with a Security section that links to the new guide.

---
*PR created automatically by Jules for task [15820602975769803837](https://jules.google.com/task/15820602975769803837) started by @JClouddd*