### PR TITLE
feat: add firebase cloud messaging support

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,0 +1,28 @@
+importScripts('https://www.gstatic.com/firebasejs/10.12.0/firebase-app-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/10.12.0/firebase-messaging-compat.js');
+
+const firebaseConfig = {
+  apiKey: "AIzaSyBCfYLKI6_lqPP76sVI2Pgq5Idb7PhmTxk",
+  authDomain: "antigravity-hub-jcloud.firebaseapp.com",
+  projectId: "antigravity-hub-jcloud",
+  storageBucket: "antigravity-hub-jcloud.firebasestorage.app",
+  messagingSenderId: "426017291723",
+  appId: "1:426017291723:web:f3cb5e26db812e291a8a4e"
+};
+
+firebase.initializeApp(firebaseConfig);
+
+const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage((payload) => {
+  console.log('[firebase-messaging-sw.js] Received background message ', payload);
+
+  const notificationTitle = payload.notification?.title || 'Gravix Notification';
+  const notificationOptions = {
+    body: payload.notification?.body || 'You have a new message.',
+    icon: '/icon512_rounded.png', // Assuming there's a default icon in PWA
+    data: payload.data
+  };
+
+  self.registration.showNotification(notificationTitle, notificationOptions);
+});

--- a/src/app/api/notifications/send/route.js
+++ b/src/app/api/notifications/send/route.js
@@ -1,0 +1,124 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/firebase';
+import { doc, getDoc } from 'firebase/firestore';
+import crypto from 'crypto';
+
+/**
+ * Creates a JWT using standard node crypto for a Google Service Account
+ */
+function createJwt(serviceAccount) {
+  const header = {
+    alg: 'RS256',
+    typ: 'JWT'
+  };
+
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    iss: serviceAccount.client_email,
+    scope: 'https://www.googleapis.com/auth/firebase.messaging',
+    aud: 'https://oauth2.googleapis.com/token',
+    exp: now + 3600,
+    iat: now
+  };
+
+  const encodedHeader = Buffer.from(JSON.stringify(header)).toString('base64url');
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
+
+  const signatureInput = `${encodedHeader}.${encodedPayload}`;
+
+  const sign = crypto.createSign('RSA-SHA256');
+  sign.update(signatureInput);
+  const signature = sign.sign(serviceAccount.private_key, 'base64url');
+
+  return `${signatureInput}.${signature}`;
+}
+
+/**
+ * Gets an access token using the service account credentials
+ */
+async function getAccessToken(serviceAccount) {
+  const jwt = createJwt(serviceAccount);
+
+  const response = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=${jwt}`
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to obtain access token');
+  }
+
+  const data = await response.json();
+  return data.access_token;
+}
+
+export async function POST(request) {
+  try {
+    const { title, body, data } = await request.json();
+
+    if (!title || !body) {
+      return NextResponse.json({ error: 'Missing title or body' }, { status: 400 });
+    }
+
+    // 1. Get FCM Token from Firestore
+    const fcmDoc = await getDoc(doc(db, "settings", "fcm_token"));
+    if (!fcmDoc.exists() || !fcmDoc.data().token) {
+      return NextResponse.json({ error: 'No FCM token found. User might not have enabled notifications.' }, { status: 404 });
+    }
+    const fcmToken = fcmDoc.data().token;
+
+    // 2. Get Service Account from ENV
+    if (!process.env.FCM_SERVICE_ACCOUNT_KEY) {
+      console.warn("FCM_SERVICE_ACCOUNT_KEY not provided. Notification request ignored in dev.");
+      return NextResponse.json({ success: false, message: 'FCM_SERVICE_ACCOUNT_KEY not configured' }, { status: 500 });
+    }
+
+    let serviceAccount;
+    try {
+      serviceAccount = JSON.parse(process.env.FCM_SERVICE_ACCOUNT_KEY);
+    } catch (e) {
+      return NextResponse.json({ error: 'Invalid FCM_SERVICE_ACCOUNT_KEY format' }, { status: 500 });
+    }
+
+    // 3. Obtain Access Token
+    const accessToken = await getAccessToken(serviceAccount);
+    const projectId = serviceAccount.project_id;
+
+    // 4. Send via FCM HTTP v1 API
+    const messagePayload = {
+      message: {
+        token: fcmToken,
+        notification: {
+          title: title,
+          body: body
+        },
+        data: data || {}
+      }
+    };
+
+    const response = await fetch(`https://fcm.googleapis.com/v1/projects/${projectId}/messages:send`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(messagePayload)
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error('FCM API Error:', errorText);
+      return NextResponse.json({ error: 'Failed to send FCM notification', details: errorText }, { status: 500 });
+    }
+
+    const responseData = await response.json();
+    return NextResponse.json({ success: true, result: responseData });
+
+  } catch (error) {
+    console.error('Error sending notification:', error);
+    return NextResponse.json({ error: error.message || 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/components/modules/SettingsModule.js
+++ b/src/components/modules/SettingsModule.js
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { requestPermission } from "@/lib/notifications";
 
 /**
  * Settings Module
@@ -44,6 +45,36 @@ export default function SettingsModule() {
   const [theme, setTheme] = useState("dark");
   const [accentColor, setAccentColor] = useState("#3b82f6");
   const [fontSize, setFontSize] = useState(14);
+
+  // Notifications State
+  const [pushEnabled, setPushEnabled] = useState(
+    typeof window !== "undefined" && "Notification" in window && Notification.permission === "granted"
+  );
+  const [fcmTokenStatus, setFcmTokenStatus] = useState(
+    typeof window !== "undefined" && "Notification" in window
+      ? (Notification.permission === "granted" ? "connected" : "not connected")
+      : "unsupported"
+  );
+
+  const handlePushToggle = async (e) => {
+    const isChecked = e.target.checked;
+    if (isChecked) {
+      setFcmTokenStatus("connecting...");
+      const token = await requestPermission();
+      if (token) {
+        setPushEnabled(true);
+        setFcmTokenStatus("connected");
+      } else {
+        setPushEnabled(false);
+        setFcmTokenStatus("failed or denied");
+      }
+    } else {
+      // Browsers don't let you easily "revoke" permission via code,
+      // but we can turn off the toggle in our UI state.
+      setPushEnabled(false);
+      setFcmTokenStatus("disabled");
+    }
+  };
 
   const presetColors = ["#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6", "#ec4899"];
 
@@ -126,8 +157,23 @@ export default function SettingsModule() {
             <div>
               <div className="body">Push Notifications</div>
               <div className="caption">Receive alerts from Sentinel and agent updates via FCM</div>
+              <div className="caption" style={{ marginTop: 4 }}>
+                Status: <span style={{ color: fcmTokenStatus === "connected" ? "var(--success)" : "var(--text-secondary)" }}>{fcmTokenStatus}</span>
+              </div>
             </div>
-            <span className="badge badge-warning">Requires PWA</span>
+            <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+              <span className="badge badge-warning">Requires PWA</span>
+              <label style={{ display: "flex", alignItems: "center", cursor: "pointer" }}>
+                <input
+                  type="checkbox"
+                  checked={pushEnabled}
+                  onChange={handlePushToggle}
+                  disabled={fcmTokenStatus === "unsupported"}
+                  style={{ width: 16, height: 16, accentColor: "var(--primary)" }}
+                />
+                <span style={{ marginLeft: 8 }} className="body-sm">{pushEnabled ? "Enabled" : "Disabled"}</span>
+              </label>
+            </div>
           </div>
         </div>
 

--- a/src/lib/notifications.js
+++ b/src/lib/notifications.js
@@ -1,0 +1,97 @@
+import { getMessaging, getToken, onMessage } from "firebase/messaging";
+import { doc, setDoc } from "firebase/firestore";
+import { app, db } from "./firebase";
+
+/**
+ * Request notification permissions from the user and get FCM token
+ */
+export async function requestPermission() {
+  try {
+    const permission = await Notification.requestPermission();
+
+    if (permission === "granted") {
+      const messaging = getMessaging(app);
+
+      const token = await getToken(messaging, {
+        // Use default configuration. VapidKey can be provided here if needed.
+      });
+
+      if (token) {
+        console.log("FCM Token obtained");
+
+        // Save to Firestore per instructions
+        await setDoc(doc(db, "settings", "fcm_token"), {
+          token: token,
+          updatedAt: new Date().toISOString()
+        }, { merge: true });
+
+        return token;
+      } else {
+        console.warn("No registration token available. Request permission to generate one.");
+        return null;
+      }
+    } else {
+      console.warn("Notification permission denied");
+      return null;
+    }
+  } catch (error) {
+    console.error("Error requesting notification permission:", error);
+    return null;
+  }
+}
+
+/**
+ * Listen for foreground messages
+ */
+export function setupForegroundMessages() {
+  try {
+    const messaging = getMessaging(app);
+
+    return onMessage(messaging, (payload) => {
+      console.log("Message received in foreground:", payload);
+
+      const title = payload.notification?.title || "Gravix Notification";
+      const body = payload.notification?.body || "You have a new message";
+
+      // Simple toast implementation (using browser alert/notification if in foreground)
+      if (Notification.permission === "granted") {
+         new Notification(title, { body });
+      } else {
+         alert(`${title}: ${body}`);
+      }
+    });
+  } catch (error) {
+    console.error("Error setting up foreground messages:", error);
+    return () => {}; // return empty unsubscribe function
+  }
+}
+
+/**
+ * Send notification via server-side API Route
+ */
+export async function sendNotification({ userId, title, body, data = {} }) {
+  try {
+    const response = await fetch("/api/notifications/send", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        userId,
+        title,
+        body,
+        data
+      })
+    });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      throw new Error(`Failed to send notification: ${errorData}`);
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error("Error calling sendNotification API:", error);
+    throw error;
+  }
+}


### PR DESCRIPTION
This PR adds support for Firebase Cloud Messaging (FCM). 
It introduces a service worker `firebase-messaging-sw.js` for background handling, a client-side utility `notifications.js` for permission requests, and a server-side route `/api/notifications/send` which cleanly generates Google Service Account JWTs using the native `crypto` module to invoke the FCM HTTP v1 API without any external dependencies.

It also wires up the UI with a Push Notifications toggle in the SettingsModule to opt-in and manage tokens in Firestore.

---
*PR created automatically by Jules for task [14487620678878934371](https://jules.google.com/task/14487620678878934371) started by @JClouddd*