### PR TITLE
feat(planner): Add Calendar color-coding and Tasks source tagging

### DIFF
--- a/dev.log
+++ b/dev.log
@@ -5,7 +5,7 @@
 ▲ Next.js 16.2.4 (Turbopack)
 - Local:         http://localhost:3000
 - Network:       http://192.168.0.2:3000
-✓ Ready in 515ms
+✓ Ready in 611ms
 ⚠ turbopack.root should be absolute, using: /app
 Attention: Next.js now collects completely anonymous telemetry regarding usage.
 This information is used to shape Next.js' roadmap and prioritize features.
@@ -13,9 +13,10 @@ You can learn more, including how to opt-out if you'd not like to participate in
 https://nextjs.org/telemetry
 
 
- GET / 200 in 3.2s (next.js: 2.9s, application-code: 307ms)
- GET / 200 in 134ms (next.js: 9ms, application-code: 125ms)
- GET / 200 in 195ms (next.js: 12ms, application-code: 182ms)
+○ Compiling /_not-found/page ...
+ GET /planner 404 in 6.0s (next.js: 5.6s, application-code: 448ms)
+ GET / 200 in 70ms (next.js: 5ms, application-code: 65ms)
+ GET / 200 in 89ms (next.js: 7ms, application-code: 82ms)
 [/api/jules/tasks GET] Error: JULES_API_KEY environment variable is not set
     at getApiKey (src/lib/julesClient.js:19:11)
     at julesRequest (src/lib/julesClient.js:27:23)
@@ -28,10 +29,54 @@ https://nextjs.org/telemetry
   20 |   }
   21 |   return key;
   22 | }
- GET / 200 in 83ms (next.js: 7ms, application-code: 76ms)
+ GET /api/jules/tasks 503 in 1503ms (next.js: 612ms, application-code: 891ms)
+ GET /api/knowledge/status 200 in 1676ms (next.js: 1654ms, application-code: 22ms)
+ GET /api/agents/roster 200 in 3.2s (next.js: 3.1s, application-code: 8ms)
+ GET /api/costs/summary 200 in 3.4s (next.js: 3.0s, application-code: 421ms)
+[/api/gemini/chat] Error: GEMINI_API_KEY environment variable is not set
+    at generate (src/lib/geminiClient.js:153:11)
+    at chat (src/lib/geminiClient.js:298:10)
+    at POST (src/app/api/gemini/chat/route.js:26:30)
+  151 |   const apiKey = process.env.GEMINI_API_KEY;
+  152 |   if (!apiKey) {
+> 153 |     throw new Error("GEMINI_API_KEY environment variable is not set");
+      |           ^
+  154 |   }
+  155 |
+  156 |   const genAI = new GoogleGenerativeAI(apiKey);
+ POST /api/gemini/chat 500 in 588ms (next.js: 395ms, application-code: 194ms)
+ GET /api/knowledge/status 200 in 7ms (next.js: 3ms, application-code: 4ms)
+[/api/jules/tasks GET] Error: JULES_API_KEY environment variable is not set
+    at getApiKey (src/lib/julesClient.js:19:11)
+    at julesRequest (src/lib/julesClient.js:27:23)
+    at listSessions (src/lib/julesClient.js:83:10)
+    at GET (src/app/api/jules/tasks/route.js:56:40)
+  17 |   const key = process.env.JULES_API_KEY;
+  18 |   if (!key) {
+> 19 |     throw new Error("JULES_API_KEY environment variable is not set");
+     |           ^
+  20 |   }
+  21 |   return key;
+  22 | }
+ GET /api/jules/tasks 503 in 145ms (next.js: 2ms, application-code: 143ms)
+[2026-04-17T23:37:52.838Z]  @firebase/firestore: Firestore (12.12.0): GrpcConnection RPC 'Write' stream 0x32d1d3c8 error. Code: 7 Message: 7 PERMISSION_DENIED: Missing or insufficient permissions.
+Error writing health history: [Error [FirebaseError]: 7 PERMISSION_DENIED: Missing or insufficient permissions.] {
+  code: 'permission-denied',
+  customData: undefined,
+  toString: [Function (anonymous)]
+}
+ POST /api/health/history 500 in 548ms (next.js: 376ms, application-code: 172ms)
+Error fetching health history: [Error [FirebaseError]: Missing or insufficient permissions.] {
+  code: 'permission-denied',
+  customData: undefined,
+  toString: [Function (anonymous)]
+}
+ GET /api/health/history 500 in 70ms (next.js: 2ms, application-code: 68ms)
+ GET /api/health 200 in 4.7s (next.js: 3.0s, application-code: 1719ms)
+ GET / 200 in 77ms (next.js: 4ms, application-code: 72ms)
  GET / 200 in 89ms (next.js: 5ms, application-code: 84ms)
- GET /api/agents/roster 200 in 12ms (next.js: 5ms, application-code: 7ms)
- GET /api/knowledge/status 200 in 19ms (next.js: 14ms, application-code: 5ms)
+ GET /api/agents/roster 200 in 14ms (next.js: 10ms, application-code: 4ms)
+ GET /api/knowledge/status 200 in 22ms (next.js: 18ms, application-code: 3ms)
 [/api/jules/tasks GET] Error: JULES_API_KEY environment variable is not set
     at getApiKey (src/lib/julesClient.js:19:11)
     at julesRequest (src/lib/julesClient.js:27:23)
@@ -44,14 +89,12 @@ https://nextjs.org/telemetry
   20 |   }
   21 |   return key;
   22 | }
- GET /api/jules/tasks 503 in 223ms (next.js: 20ms, application-code: 203ms)
- GET /api/costs/summary 200 in 243ms (next.js: 5ms, application-code: 237ms)
- GET /api/email/inbox 200 in 304ms (next.js: 3ms, application-code: 301ms)
- GET /api/email/inbox 200 in 284ms (next.js: 2ms, application-code: 282ms)
-[/api/email/classify] Error: GEMINI_API_KEY environment variable is not set
+ GET /api/jules/tasks 503 in 197ms (next.js: 3ms, application-code: 194ms)
+ GET /api/costs/summary 200 in 276ms (next.js: 13ms, application-code: 263ms)
+[/api/gemini/chat] Error: GEMINI_API_KEY environment variable is not set
     at generate (src/lib/geminiClient.js:153:11)
-    at structuredGenerate (src/lib/geminiClient.js:436:10)
-    at POST (src/app/api/email/classify/route.js:58:44)
+    at chat (src/lib/geminiClient.js:298:10)
+    at POST (src/app/api/gemini/chat/route.js:26:30)
   151 |   const apiKey = process.env.GEMINI_API_KEY;
   152 |   if (!apiKey) {
 > 153 |     throw new Error("GEMINI_API_KEY environment variable is not set");
@@ -59,11 +102,8 @@ https://nextjs.org/telemetry
   154 |   }
   155 |
   156 |   const genAI = new GoogleGenerativeAI(apiKey);
- POST /api/email/classify 500 in 463ms (next.js: 145ms, application-code: 318ms)
- GET / 200 in 73ms (next.js: 4ms, application-code: 69ms)
- GET / 200 in 84ms (next.js: 6ms, application-code: 78ms)
- GET /api/agents/roster 200 in 14ms (next.js: 10ms, application-code: 5ms)
- GET /api/knowledge/status 200 in 17ms (next.js: 12ms, application-code: 5ms)
+ POST /api/gemini/chat 500 in 179ms (next.js: 19ms, application-code: 160ms)
+ GET /api/knowledge/status 200 in 7ms (next.js: 3ms, application-code: 4ms)
 [/api/jules/tasks GET] Error: JULES_API_KEY environment variable is not set
     at getApiKey (src/lib/julesClient.js:19:11)
     at julesRequest (src/lib/julesClient.js:27:23)
@@ -76,102 +116,22 @@ https://nextjs.org/telemetry
   20 |   }
   21 |   return key;
   22 | }
- GET /api/jules/tasks 503 in 242ms (next.js: 18ms, application-code: 224ms)
- GET /api/costs/summary 200 in 324ms (next.js: 6ms, application-code: 318ms)
- GET /api/email/inbox 200 in 153ms (next.js: 3ms, application-code: 150ms)
- GET / 200 in 54ms (next.js: 3ms, application-code: 51ms)
- GET / 200 in 85ms (next.js: 3ms, application-code: 82ms)
- GET /api/agents/roster 200 in 9ms (next.js: 5ms, application-code: 4ms)
- GET /api/knowledge/status 200 in 13ms (next.js: 9ms, application-code: 4ms)
-[/api/jules/tasks GET] Error: JULES_API_KEY environment variable is not set
-    at getApiKey (src/lib/julesClient.js:19:11)
-    at julesRequest (src/lib/julesClient.js:27:23)
-    at listSessions (src/lib/julesClient.js:83:10)
-    at GET (src/app/api/jules/tasks/route.js:56:40)
-  17 |   const key = process.env.JULES_API_KEY;
-  18 |   if (!key) {
-> 19 |     throw new Error("JULES_API_KEY environment variable is not set");
-     |           ^
-  20 |   }
-  21 |   return key;
-  22 | }
- GET /api/jules/tasks 503 in 151ms (next.js: 14ms, application-code: 137ms)
- GET /api/costs/summary 200 in 167ms (next.js: 14ms, application-code: 153ms)
- GET /api/email/inbox 200 in 334ms (next.js: 3ms, application-code: 331ms)
- GET /api/email/inbox 200 in 393ms (next.js: 8ms, application-code: 385ms)
-[/api/email/classify] Error: GEMINI_API_KEY environment variable is not set
-    at generate (src/lib/geminiClient.js:153:11)
-    at structuredGenerate (src/lib/geminiClient.js:436:10)
-    at POST (src/app/api/email/classify/route.js:58:44)
-  151 |   const apiKey = process.env.GEMINI_API_KEY;
-  152 |   if (!apiKey) {
-> 153 |     throw new Error("GEMINI_API_KEY environment variable is not set");
-      |           ^
-  154 |   }
-  155 |
-  156 |   const genAI = new GoogleGenerativeAI(apiKey);
- POST /api/email/classify 500 in 145ms (next.js: 3ms, application-code: 142ms)
- GET / 200 in 65ms (next.js: 4ms, application-code: 61ms)
- GET / 200 in 85ms (next.js: 3ms, application-code: 83ms)
- GET /api/agents/roster 200 in 11ms (next.js: 4ms, application-code: 7ms)
- GET /api/knowledge/status 200 in 23ms (next.js: 19ms, application-code: 4ms)
-[/api/jules/tasks GET] Error: JULES_API_KEY environment variable is not set
-    at getApiKey (src/lib/julesClient.js:19:11)
-    at julesRequest (src/lib/julesClient.js:27:23)
-    at listSessions (src/lib/julesClient.js:83:10)
-    at GET (src/app/api/jules/tasks/route.js:56:40)
-  17 |   const key = process.env.JULES_API_KEY;
-  18 |   if (!key) {
-> 19 |     throw new Error("JULES_API_KEY environment variable is not set");
-     |           ^
-  20 |   }
-  21 |   return key;
-  22 | }
- GET /api/jules/tasks 503 in 185ms (next.js: 8ms, application-code: 176ms)
- GET /api/costs/summary 200 in 224ms (next.js: 12ms, application-code: 212ms)
- GET /api/email/inbox 200 in 389ms (next.js: 3ms, application-code: 386ms)
- GET /api/email/inbox 200 in 1052ms (next.js: 1966µs, application-code: 1050ms)
-[/api/email/classify] Error: GEMINI_API_KEY environment variable is not set
-    at generate (src/lib/geminiClient.js:153:11)
-    at structuredGenerate (src/lib/geminiClient.js:436:10)
-    at POST (src/app/api/email/classify/route.js:58:44)
-  151 |   const apiKey = process.env.GEMINI_API_KEY;
-  152 |   if (!apiKey) {
-> 153 |     throw new Error("GEMINI_API_KEY environment variable is not set");
-      |           ^
-  154 |   }
-  155 |
-  156 |   const genAI = new GoogleGenerativeAI(apiKey);
- POST /api/email/classify 500 in 166ms (next.js: 3ms, application-code: 163ms)
- GET / 200 in 60ms (next.js: 4ms, application-code: 56ms)
- GET / 200 in 65ms (next.js: 4ms, application-code: 61ms)
- GET /api/agents/roster 200 in 9ms (next.js: 5ms, application-code: 4ms)
- GET /api/knowledge/status 200 in 17ms (next.js: 12ms, application-code: 5ms)
-[/api/jules/tasks GET] Error: JULES_API_KEY environment variable is not set
-    at getApiKey (src/lib/julesClient.js:19:11)
-    at julesRequest (src/lib/julesClient.js:27:23)
-    at listSessions (src/lib/julesClient.js:83:10)
-    at GET (src/app/api/jules/tasks/route.js:56:40)
-  17 |   const key = process.env.JULES_API_KEY;
-  18 |   if (!key) {
-> 19 |     throw new Error("JULES_API_KEY environment variable is not set");
-     |           ^
-  20 |   }
-  21 |   return key;
-  22 | }
- GET /api/jules/tasks 503 in 199ms (next.js: 22ms, application-code: 178ms)
- GET /api/costs/summary 200 in 272ms (next.js: 4ms, application-code: 268ms)
- GET /api/email/inbox 200 in 308ms (next.js: 3ms, application-code: 305ms)
- GET /api/email/inbox 200 in 237ms (next.js: 2ms, application-code: 235ms)
-[/api/email/classify] Error: GEMINI_API_KEY environment variable is not set
-    at generate (src/lib/geminiClient.js:153:11)
-    at structuredGenerate (src/lib/geminiClient.js:436:10)
-    at POST (src/app/api/email/classify/route.js:58:44)
-  151 |   const apiKey = process.env.GEMINI_API_KEY;
-  152 |   if (!apiKey) {
-> 153 |     throw new Error("GEMINI_API_KEY environment variable is not set");
-      |           ^
-  154 |   }
-  155 |
-  156 |   const genAI = new GoogleGenerativeAI(apiKey);
- POST /api/email/classify 500 in 172ms (next.js: 2ms, application-code: 170ms)
+ GET /api/jules/tasks 503 in 153ms (next.js: 3ms, application-code: 150ms)
+[2026-04-17T23:38:35.139Z]  @firebase/firestore: Firestore (12.12.0): GrpcConnection RPC 'Write' stream 0x32d1d3c9 error. Code: 7 Message: 7 PERMISSION_DENIED: Missing or insufficient permissions.
+Error writing health history: [Error [FirebaseError]: 7 PERMISSION_DENIED: Missing or insufficient permissions.] {
+  code: 'permission-denied',
+  customData: undefined,
+  toString: [Function (anonymous)]
+}
+ POST /api/health/history 500 in 156ms (next.js: 3ms, application-code: 153ms)
+Error fetching health history: [Error [FirebaseError]: Missing or insufficient permissions.] {
+  code: 'permission-denied',
+  customData: undefined,
+  toString: [Function (anonymous)]
+}
+ GET /api/health/history 500 in 55ms (next.js: 2ms, application-code: 52ms)
+ GET /api/health 200 in 883ms (next.js: 199ms, application-code: 684ms)
+ GET /api/calendar/events 200 in 411ms (next.js: 274ms, application-code: 137ms)
+ GET /api/tasks/list 200 in 415ms (next.js: 331ms, application-code: 84ms)
+ GET /api/calendar/events 200 in 73ms (next.js: 2ms, application-code: 70ms)
+ GET /api/tasks/list 200 in 69ms (next.js: 1772µs, application-code: 67ms)

--- a/src/app/api/calendar/events/route.js
+++ b/src/app/api/calendar/events/route.js
@@ -1,5 +1,5 @@
 import { getCalendarEvents, refreshAccessToken } from "@/lib/googleAuth";
-import { doc, getDoc, updateDoc } from "firebase/firestore";
+import { doc, getDoc, updateDoc, collection, getDocs } from "firebase/firestore";
 import { db } from "@/lib/firebase";
 
 export async function GET() {
@@ -39,18 +39,47 @@ export async function GET() {
     const eventsResponse = await getCalendarEvents(accessToken);
     const rawEvents = eventsResponse.items || eventsResponse || [];
 
+    // Fetch clients to check for attendee matches
+    const clientsSnapshot = await getDocs(collection(db, "clients"));
+    const clientEmails = new Set();
+    clientsSnapshot.forEach(doc => {
+      const data = doc.data();
+      if (data.email) {
+        clientEmails.add(data.email.toLowerCase());
+      }
+    });
+
     // Safely map and extract fields
     const mappedEvents = (Array.isArray(rawEvents) ? rawEvents : []).map((evt) => {
       const start = evt.start?.dateTime || evt.start?.date || "";
       const end = evt.end?.dateTime || evt.end?.date || "";
+      const summary = evt.summary || "Untitled Event";
+      const attendees = evt.attendees || [];
+
+      let sourceType = "personal";
+      let color = "#22c55e"; // Default: green
+
+      if (summary.startsWith("Follow-up") || summary.startsWith("Kickoff")) {
+        sourceType = "agent";
+        color = "#8b5cf6"; // Purple
+      } else {
+        const hasClient = attendees.some(a => a.email && clientEmails.has(a.email.toLowerCase()));
+        if (hasClient) {
+          sourceType = "client";
+          color = "#3b82f6"; // Blue
+        }
+      }
+
       return {
         id: evt.id,
-        summary: evt.summary || "Untitled Event",
+        summary,
         start,
         end,
         location: evt.location || "",
         meetLink: evt.hangoutLink || "",
-        attendees: evt.attendees || [],
+        attendees,
+        sourceType,
+        color,
       };
     });
 

--- a/src/app/api/tasks/list/route.js
+++ b/src/app/api/tasks/list/route.js
@@ -46,11 +46,31 @@ export async function GET() {
       try {
         const tasksRes = await getTasks(accessToken, list.id);
         const tasks = tasksRes.items || [];
-        return tasks.map(task => ({
-          ...task,
-          listId: list.id,
-          listTitle: list.title
-        }));
+        return tasks.map(task => {
+          let source = "manual";
+          let sourceIcon = "✋";
+
+          if (task.notes) {
+            if (task.notes.includes("Source: Email")) {
+              source = "email";
+              sourceIcon = "✉️";
+            } else if (task.notes.includes("From meeting")) {
+              source = "meeting";
+              sourceIcon = "🎙️";
+            } else if (task.notes.includes("Agent:")) {
+              source = "agent";
+              sourceIcon = "🤖";
+            }
+          }
+
+          return {
+            ...task,
+            listId: list.id,
+            listTitle: list.title,
+            source,
+            sourceIcon
+          };
+        });
       } catch (e) {
         console.error(`Failed to fetch tasks for list ${list.id}`, e);
         return [];

--- a/src/components/modules/PlannerModule.js
+++ b/src/components/modules/PlannerModule.js
@@ -27,6 +27,10 @@ export default function PlannerModule() {
   const [showAddTask, setShowAddTask] = useState(false);
   const [newTask, setNewTask] = useState({ title: "", dueDate: "", priority: "Medium" });
 
+  // Filter State
+  const [calendarFilter, setCalendarFilter] = useState("All");
+  const [tasksFilter, setTasksFilter] = useState("All");
+
   useEffect(() => {
     let isMounted = true;
     async function fetchData() {
@@ -46,10 +50,11 @@ export default function PlannerModule() {
               const dateObj = evt.start ? new Date(evt.start) : new Date();
               return {
                 id: evt.id,
-                title: evt.summary,
+                title: evt.summary || evt.title,
                 date: dateObj,
                 type: "event",
-                color: "var(--accent)", // random color placeholder
+                color: evt.color || "var(--accent)",
+                sourceType: evt.sourceType || "personal",
                 start: evt.start ? new Date(evt.start).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false }) : "00:00",
                 end: evt.end ? new Date(evt.end).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false }) : "00:00",
                 location: evt.location,
@@ -75,7 +80,9 @@ export default function PlannerModule() {
                 title: task.title,
                 dueDate: task.due ? task.due.substring(0, 10) : "",
                 priority: "Medium", // Google Tasks API doesn't expose priority clearly
-                completed: task.status === "completed"
+                completed: task.status === "completed",
+                source: task.source || "manual",
+                sourceIcon: task.sourceIcon || "✋"
               };
             });
             setTasks(mappedTasks);
@@ -187,7 +194,12 @@ export default function PlannerModule() {
       );
     }
 
-    const selectedEvents = calendarEvents.filter(
+    const filteredCalendarEvents = calendarEvents.filter(e => {
+      if (calendarFilter === "All") return true;
+      return e.sourceType?.toLowerCase() === calendarFilter.toLowerCase();
+    });
+
+    const selectedEvents = filteredCalendarEvents.filter(
       (e) =>
         e.date.getDate() === selectedDate.getDate() &&
         e.date.getMonth() === selectedDate.getMonth() &&
@@ -195,6 +207,18 @@ export default function PlannerModule() {
     );
 
     return (
+      <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+        <div style={{ display: "flex", gap: "8px", marginBottom: "8px" }}>
+          {["All", "Client", "Agent", "Personal"].map(filter => (
+            <button
+              key={filter}
+              className={`btn btn-sm ${calendarFilter === filter ? 'btn-primary' : 'btn-secondary'}`}
+              onClick={() => setCalendarFilter(filter)}
+            >
+              {filter}
+            </button>
+          ))}
+        </div>
       <div className="grid-2" style={{ gridTemplateColumns: "3fr 1fr", gap: "24px" }}>
         <div className="card">
           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "16px" }}>
@@ -225,7 +249,10 @@ export default function PlannerModule() {
             <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
               {selectedEvents.map(evt => (
                 <div key={evt.id} style={{ padding: "12px", borderRadius: "var(--radius-md)", background: "var(--bg-tertiary)", borderLeft: `3px solid ${evt.color}` }}>
-                  <div style={{ fontWeight: "bold", fontSize: "14px", marginBottom: "4px" }}>{evt.title}</div>
+                  <div style={{ fontWeight: "bold", fontSize: "14px", marginBottom: "4px", display: "flex", alignItems: "center", gap: "8px" }}>
+                    <span style={{ display: "inline-block", width: "8px", height: "8px", borderRadius: "50%", backgroundColor: evt.color }} />
+                    {evt.title}
+                  </div>
                   <div style={{ fontSize: "12px", color: "var(--text-secondary)" }}>{evt.start} - {evt.end}</div>
                 </div>
               ))}
@@ -233,11 +260,17 @@ export default function PlannerModule() {
           )}
         </div>
       </div>
+      </div>
     );
   };
 
   const renderTasks = () => {
-    const sortedTasks = [...tasks].sort((a, b) => {
+    const filteredTasks = tasks.filter(task => {
+      if (tasksFilter === "All") return true;
+      return task.source?.toLowerCase() === tasksFilter.toLowerCase();
+    });
+
+    const sortedTasks = [...filteredTasks].sort((a, b) => {
       if (taskSort === "date") {
         return new Date(a.dueDate) - new Date(b.dueDate);
       } else {
@@ -268,6 +301,18 @@ export default function PlannerModule() {
     };
 
     return (
+      <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+        <div style={{ display: "flex", gap: "8px", marginBottom: "8px" }}>
+          {["All", "Manual", "Email", "Meeting", "Agent"].map(filter => (
+            <button
+              key={filter}
+              className={`btn btn-sm ${tasksFilter === filter ? 'btn-primary' : 'btn-secondary'}`}
+              onClick={() => setTasksFilter(filter)}
+            >
+              {filter}
+            </button>
+          ))}
+        </div>
       <div className="card">
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "20px" }}>
           <h3 className="h4">Task List</h3>
@@ -319,6 +364,7 @@ export default function PlannerModule() {
                   onChange={() => toggleTask(task.id)}
                   style={{ width: "16px", height: "16px", cursor: "pointer" }}
                 />
+                <span style={{ fontSize: "16px" }}>{task.sourceIcon}</span>
                 <span style={{ fontSize: "14px", textDecoration: task.completed ? "line-through" : "none", color: task.completed ? "var(--text-secondary)" : "var(--text-primary)" }}>
                   {task.title}
                 </span>
@@ -330,6 +376,7 @@ export default function PlannerModule() {
             </div>
           ))}
         </div>
+      </div>
       </div>
     );
   };


### PR DESCRIPTION
This PR implements source tagging and color-coding for events and tasks within the Planner module.

**Changes:**
1.  **Calendar Events Enrichment:** Updated the `GET` route in `src/app/api/calendar/events/route.js` to cross-reference event attendees with the `clients` collection in Firestore. It now assigns a `sourceType` (client, agent, or personal) and an associated `color` hex code based on attendee matches and specific summary prefixes ("Follow-up" or "Kickoff").
2.  **Tasks Source Tagging:** Updated the `GET` route in `src/app/api/tasks/list/route.js` to analyze task notes for source hints ("Source: Email", "From meeting", "Agent:"). It assigns a specific `source` string and a corresponding `sourceIcon` emoji to each task.
3.  **PlannerModule Updates:**
    *   Added filter states and buttons for both the Calendar ("All", "Client", "Agent", "Personal") and Tasks sections ("All", "Manual", "Email", "Meeting", "Agent").
    *   Updated the UI to correctly map and render the API-provided `color` (as a colored dot next to events) and `sourceIcon` (next to tasks) while adhering to the existing CSS constraints.

**Verification:**
-   Verified UI functionally through a local Playwright script taking screenshots.
-   All existing Vitest suites passed.
-   Code meets all linting requirements.

---
*PR created automatically by Jules for task [10606043428838606707](https://jules.google.com/task/10606043428838606707) started by @JClouddd*