### PR TITLE
feat(agents): add configurations and tools for Courier, Analyst, Builder, and Forge

### DIFF
--- a/agents/analyst/agent.yaml
+++ b/agents/analyst/agent.yaml
@@ -1,0 +1,11 @@
+name: Analyst
+model: gemini-2.0-flash
+description: Data science agent that executes notebooks, analyzes data, and generates
+  insights
+instruction: You are Analyst, the data science agent of Gravix. You execute Jupyter
+  notebooks via Cloud Run, analyze financial data, health trends, and business metrics.
+  You can run stock analysis, portfolio optimization, and custom data pipelines.
+tools:
+- execute_notebook
+- analyze_data
+- format_results

--- a/agents/analyst/tools/analyze_data.py
+++ b/agents/analyst/tools/analyze_data.py
@@ -1,0 +1,46 @@
+"""
+General data analysis using Gemini
+"""
+from typing import Dict, Any
+
+TOOL_SCHEMA = {
+    'description': 'General data analysis using Gemini',
+    'parameters': {
+    "type": "object",
+    "properties": {
+        "data": {
+            "type": "object"
+        },
+        "analysis_type": {
+            "type": "string"
+        },
+        "question": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "data",
+        "analysis_type",
+        "question"
+    ]
+},
+    'returns': {
+    "analysis": "string",
+    "insights": "array",
+    "recommendations": "array"
+}
+}
+
+
+def execute(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Executes the analyze_data tool.
+
+    Args:
+        params: The parameters for the tool as defined in TOOL_SCHEMA.
+
+    Returns:
+        The result of the tool execution as defined in TOOL_SCHEMA.
+    """
+    # TODO: Implement tool logic
+    pass

--- a/agents/analyst/tools/execute_notebook.py
+++ b/agents/analyst/tools/execute_notebook.py
@@ -1,0 +1,42 @@
+"""
+Triggers Cloud Run notebook execution
+"""
+from typing import Dict, Any
+
+TOOL_SCHEMA = {
+    'description': 'Triggers Cloud Run notebook execution',
+    'parameters': {
+    "type": "object",
+    "properties": {
+        "notebook": {
+            "type": "string"
+        },
+        "parameters": {
+            "type": "object"
+        }
+    },
+    "required": [
+        "notebook",
+        "parameters"
+    ]
+},
+    'returns': {
+    "results": "object",
+    "chart_urls": "array",
+    "execution_time": "number"
+}
+}
+
+
+def execute(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Executes the execute_notebook tool.
+
+    Args:
+        params: The parameters for the tool as defined in TOOL_SCHEMA.
+
+    Returns:
+        The result of the tool execution as defined in TOOL_SCHEMA.
+    """
+    # TODO: Implement tool logic
+    pass

--- a/agents/analyst/tools/format_results.py
+++ b/agents/analyst/tools/format_results.py
@@ -1,0 +1,46 @@
+"""
+Formats analysis results for display
+"""
+from typing import Dict, Any
+
+TOOL_SCHEMA = {
+    'description': 'Formats analysis results for display',
+    'parameters': {
+    "type": "object",
+    "properties": {
+        "raw_results": {
+            "type": "object"
+        },
+        "format": {
+            "type": "string",
+            "enum": [
+                "table",
+                "chart",
+                "summary"
+            ]
+        }
+    },
+    "required": [
+        "raw_results",
+        "format"
+    ]
+},
+    'returns': {
+    "formatted": "object",
+    "visualization_type": "string"
+}
+}
+
+
+def execute(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Executes the format_results tool.
+
+    Args:
+        params: The parameters for the tool as defined in TOOL_SCHEMA.
+
+    Returns:
+        The result of the tool execution as defined in TOOL_SCHEMA.
+    """
+    # TODO: Implement tool logic
+    pass

--- a/agents/builder/agent.yaml
+++ b/agents/builder/agent.yaml
@@ -1,0 +1,11 @@
+name: Builder
+model: gemini-2.0-flash
+description: Development agent that extracts code patterns, generates code, and manages
+  Jules tasks
+instruction: You are Builder, the development agent of Gravix. You analyze merged
+  PRs for reusable patterns, generate code snippets, and create Jules tasks for autonomous
+  development. You maintain a pattern library and suggest refactors.
+tools:
+- extract_patterns
+- generate_code
+- create_jules_task

--- a/agents/builder/tools/create_jules_task.py
+++ b/agents/builder/tools/create_jules_task.py
@@ -1,0 +1,45 @@
+"""
+Creates a Jules task for autonomous execution
+"""
+from typing import Dict, Any
+
+TOOL_SCHEMA = {
+    'description': 'Creates a Jules task for autonomous execution',
+    'parameters': {
+    "type": "object",
+    "properties": {
+        "title": {
+            "type": "string"
+        },
+        "prompt": {
+            "type": "string"
+        },
+        "branch": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "title",
+        "prompt",
+        "branch"
+    ]
+},
+    'returns': {
+    "session_id": "string",
+    "status": "string"
+}
+}
+
+
+def execute(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Executes the create_jules_task tool.
+
+    Args:
+        params: The parameters for the tool as defined in TOOL_SCHEMA.
+
+    Returns:
+        The result of the tool execution as defined in TOOL_SCHEMA.
+    """
+    # TODO: Implement tool logic
+    pass

--- a/agents/builder/tools/extract_patterns.py
+++ b/agents/builder/tools/extract_patterns.py
@@ -1,0 +1,47 @@
+"""
+Analyzes code changes for reusable patterns
+"""
+from typing import Dict, Any
+
+TOOL_SCHEMA = {
+    'description': 'Analyzes code changes for reusable patterns',
+    'parameters': {
+    "type": "object",
+    "properties": {
+        "pr_files": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "filename": {
+                        "type": "string"
+                    },
+                    "patch": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    },
+    "required": [
+        "pr_files"
+    ]
+},
+    'returns': {
+    "patterns": "array"
+}
+}
+
+
+def execute(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Executes the extract_patterns tool.
+
+    Args:
+        params: The parameters for the tool as defined in TOOL_SCHEMA.
+
+    Returns:
+        The result of the tool execution as defined in TOOL_SCHEMA.
+    """
+    # TODO: Implement tool logic
+    pass

--- a/agents/builder/tools/generate_code.py
+++ b/agents/builder/tools/generate_code.py
@@ -1,0 +1,49 @@
+"""
+Generates code based on spec and existing patterns
+"""
+from typing import Dict, Any
+
+TOOL_SCHEMA = {
+    'description': 'Generates code based on spec and existing patterns',
+    'parameters': {
+    "type": "object",
+    "properties": {
+        "spec": {
+            "type": "string"
+        },
+        "language": {
+            "type": "string"
+        },
+        "patterns_to_use": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "required": [
+        "spec",
+        "language",
+        "patterns_to_use"
+    ]
+},
+    'returns': {
+    "code": "string",
+    "files": "array",
+    "explanation": "string"
+}
+}
+
+
+def execute(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Executes the generate_code tool.
+
+    Args:
+        params: The parameters for the tool as defined in TOOL_SCHEMA.
+
+    Returns:
+        The result of the tool execution as defined in TOOL_SCHEMA.
+    """
+    # TODO: Implement tool logic
+    pass

--- a/agents/courier/agent.yaml
+++ b/agents/courier/agent.yaml
@@ -1,0 +1,17 @@
+name: Courier
+model: gemini-2.0-flash
+description: Communications agent handling email, calendar, tasks, notifications,
+  and meeting notes
+instruction: You are Courier, the communications nerve center of Gravix. You manage
+  all Gmail operations (classify, compose, summarize), Google Calendar (create events,
+  check availability), Google Tasks (create, complete, organize), FCM push notifications,
+  and Google Meet transcript processing. You learn email templates from patterns and
+  auto-tag communications to client profiles.
+tools:
+- email_classify
+- email_compose
+- calendar_manage
+- task_manage
+- send_notification
+- learn_templates
+- process_meeting

--- a/agents/courier/tools/calendar_manage.py
+++ b/agents/courier/tools/calendar_manage.py
@@ -1,0 +1,47 @@
+"""
+Creates, updates, or queries calendar events
+"""
+from typing import Dict, Any
+
+TOOL_SCHEMA = {
+    'description': 'Creates, updates, or queries calendar events',
+    'parameters': {
+    "type": "object",
+    "properties": {
+        "action": {
+            "type": "string",
+            "enum": [
+                "create",
+                "update",
+                "query"
+            ]
+        },
+        "event_data": {
+            "type": "object"
+        }
+    },
+    "required": [
+        "action",
+        "event_data"
+    ]
+},
+    'returns': {
+    "success": "boolean",
+    "event_id": "string",
+    "events": "array"
+}
+}
+
+
+def execute(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Executes the calendar_manage tool.
+
+    Args:
+        params: The parameters for the tool as defined in TOOL_SCHEMA.
+
+    Returns:
+        The result of the tool execution as defined in TOOL_SCHEMA.
+    """
+    # TODO: Implement tool logic
+    pass

--- a/agents/courier/tools/email_classify.py
+++ b/agents/courier/tools/email_classify.py
@@ -1,0 +1,46 @@
+"""
+Classifies email into categories: client, action-required, invoice, newsletter, personal
+"""
+from typing import Dict, Any
+
+TOOL_SCHEMA = {
+    'description': 'Classifies email into categories: client, action-required, invoice, newsletter, personal',
+    'parameters': {
+    "type": "object",
+    "properties": {
+        "subject": {
+            "type": "string"
+        },
+        "from_addr": {
+            "type": "string"
+        },
+        "snippet": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "subject",
+        "from_addr",
+        "snippet"
+    ]
+},
+    'returns': {
+    "category": "string",
+    "urgency": "string",
+    "confidence": "number"
+}
+}
+
+
+def execute(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Executes the email_classify tool.
+
+    Args:
+        params: The parameters for the tool as defined in TOOL_SCHEMA.
+
+    Returns:
+        The result of the tool execution as defined in TOOL_SCHEMA.
+    """
+    # TODO: Implement tool logic
+    pass

--- a/agents/courier/tools/email_compose.py
+++ b/agents/courier/tools/email_compose.py
@@ -1,0 +1,50 @@
+"""
+Drafts email using context and templates
+"""
+from typing import Dict, Any
+
+TOOL_SCHEMA = {
+    'description': 'Drafts email using context and templates',
+    'parameters': {
+    "type": "object",
+    "properties": {
+        "to": {
+            "type": "string"
+        },
+        "subject_hint": {
+            "type": "string"
+        },
+        "context": {
+            "type": "string"
+        },
+        "tone": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "to",
+        "subject_hint",
+        "context",
+        "tone"
+    ]
+},
+    'returns': {
+    "subject": "string",
+    "body": "string",
+    "suggested_attachments": "array"
+}
+}
+
+
+def execute(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Executes the email_compose tool.
+
+    Args:
+        params: The parameters for the tool as defined in TOOL_SCHEMA.
+
+    Returns:
+        The result of the tool execution as defined in TOOL_SCHEMA.
+    """
+    # TODO: Implement tool logic
+    pass

--- a/agents/courier/tools/learn_templates.py
+++ b/agents/courier/tools/learn_templates.py
@@ -1,0 +1,47 @@
+"""
+Analyzes sent emails for patterns and creates templates
+"""
+from typing import Dict, Any
+
+TOOL_SCHEMA = {
+    'description': 'Analyzes sent emails for patterns and creates templates',
+    'parameters': {
+    "type": "object",
+    "properties": {
+        "emails": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "subject": {
+                        "type": "string"
+                    },
+                    "body": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    },
+    "required": [
+        "emails"
+    ]
+},
+    'returns': {
+    "templates": "array"
+}
+}
+
+
+def execute(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Executes the learn_templates tool.
+
+    Args:
+        params: The parameters for the tool as defined in TOOL_SCHEMA.
+
+    Returns:
+        The result of the tool execution as defined in TOOL_SCHEMA.
+    """
+    # TODO: Implement tool logic
+    pass

--- a/agents/courier/tools/process_meeting.py
+++ b/agents/courier/tools/process_meeting.py
@@ -1,0 +1,46 @@
+"""
+Processes meeting transcript and extracts action items
+"""
+from typing import Dict, Any
+
+TOOL_SCHEMA = {
+    'description': 'Processes meeting transcript and extracts action items',
+    'parameters': {
+    "type": "object",
+    "properties": {
+        "transcript": {
+            "type": "string"
+        },
+        "attendees": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "required": [
+        "transcript",
+        "attendees"
+    ]
+},
+    'returns': {
+    "summary": "string",
+    "action_items": "array",
+    "decisions": "array",
+    "follow_ups": "array"
+}
+}
+
+
+def execute(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Executes the process_meeting tool.
+
+    Args:
+        params: The parameters for the tool as defined in TOOL_SCHEMA.
+
+    Returns:
+        The result of the tool execution as defined in TOOL_SCHEMA.
+    """
+    # TODO: Implement tool logic
+    pass

--- a/agents/courier/tools/send_notification.py
+++ b/agents/courier/tools/send_notification.py
@@ -1,0 +1,49 @@
+"""
+Sends FCM push notification
+"""
+from typing import Dict, Any
+
+TOOL_SCHEMA = {
+    'description': 'Sends FCM push notification',
+    'parameters': {
+    "type": "object",
+    "properties": {
+        "title": {
+            "type": "string"
+        },
+        "body": {
+            "type": "string"
+        },
+        "data": {
+            "type": "object"
+        },
+        "topic": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "title",
+        "body",
+        "data",
+        "topic"
+    ]
+},
+    'returns': {
+    "sent": "boolean",
+    "message_id": "string"
+}
+}
+
+
+def execute(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Executes the send_notification tool.
+
+    Args:
+        params: The parameters for the tool as defined in TOOL_SCHEMA.
+
+    Returns:
+        The result of the tool execution as defined in TOOL_SCHEMA.
+    """
+    # TODO: Implement tool logic
+    pass

--- a/agents/courier/tools/task_manage.py
+++ b/agents/courier/tools/task_manage.py
@@ -1,0 +1,47 @@
+"""
+Creates or completes Google Tasks
+"""
+from typing import Dict, Any
+
+TOOL_SCHEMA = {
+    'description': 'Creates or completes Google Tasks',
+    'parameters': {
+    "type": "object",
+    "properties": {
+        "action": {
+            "type": "string",
+            "enum": [
+                "create",
+                "complete",
+                "list"
+            ]
+        },
+        "task_data": {
+            "type": "object"
+        }
+    },
+    "required": [
+        "action",
+        "task_data"
+    ]
+},
+    'returns': {
+    "success": "boolean",
+    "task_id": "string",
+    "tasks": "array"
+}
+}
+
+
+def execute(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Executes the task_manage tool.
+
+    Args:
+        params: The parameters for the tool as defined in TOOL_SCHEMA.
+
+    Returns:
+        The result of the tool execution as defined in TOOL_SCHEMA.
+    """
+    # TODO: Implement tool logic
+    pass

--- a/agents/forge/agent.yaml
+++ b/agents/forge/agent.yaml
@@ -1,0 +1,11 @@
+name: Forge
+model: gemini-2.0-flash
+description: DevOps agent managing secrets, IAM, API configuration, and infrastructure
+instruction: 'You are Forge, the DevOps agent of Gravix. You manage Google Cloud infrastructure:
+  Secret Manager for credential rotation, IAM for access control, API configuration
+  and restrictions, and service account management. You auto-detect API changes and
+  update configurations.'
+tools:
+- manage_secrets
+- manage_iam
+- configure_apis

--- a/agents/forge/tools/configure_apis.py
+++ b/agents/forge/tools/configure_apis.py
@@ -1,0 +1,53 @@
+"""
+Manages API enablement and key restrictions
+"""
+from typing import Dict, Any
+
+TOOL_SCHEMA = {
+    'description': 'Manages API enablement and key restrictions',
+    'parameters': {
+    "type": "object",
+    "properties": {
+        "action": {
+            "type": "string",
+            "enum": [
+                "list",
+                "enable",
+                "restrict"
+            ]
+        },
+        "api_name": {
+            "type": "string"
+        },
+        "restrictions": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "required": [
+        "action",
+        "api_name",
+        "restrictions"
+    ]
+},
+    'returns': {
+    "success": "boolean",
+    "status": "string"
+}
+}
+
+
+def execute(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Executes the configure_apis tool.
+
+    Args:
+        params: The parameters for the tool as defined in TOOL_SCHEMA.
+
+    Returns:
+        The result of the tool execution as defined in TOOL_SCHEMA.
+    """
+    # TODO: Implement tool logic
+    pass

--- a/agents/forge/tools/manage_iam.py
+++ b/agents/forge/tools/manage_iam.py
@@ -1,0 +1,50 @@
+"""
+Manages IAM roles and service accounts
+"""
+from typing import Dict, Any
+
+TOOL_SCHEMA = {
+    'description': 'Manages IAM roles and service accounts',
+    'parameters': {
+    "type": "object",
+    "properties": {
+        "action": {
+            "type": "string",
+            "enum": [
+                "list_roles",
+                "add_role",
+                "remove_role"
+            ]
+        },
+        "member": {
+            "type": "string"
+        },
+        "role": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "action",
+        "member",
+        "role"
+    ]
+},
+    'returns': {
+    "success": "boolean",
+    "current_roles": "array"
+}
+}
+
+
+def execute(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Executes the manage_iam tool.
+
+    Args:
+        params: The parameters for the tool as defined in TOOL_SCHEMA.
+
+    Returns:
+        The result of the tool execution as defined in TOOL_SCHEMA.
+    """
+    # TODO: Implement tool logic
+    pass

--- a/agents/forge/tools/manage_secrets.py
+++ b/agents/forge/tools/manage_secrets.py
@@ -1,0 +1,51 @@
+"""
+Manages Secret Manager secrets
+"""
+from typing import Dict, Any
+
+TOOL_SCHEMA = {
+    'description': 'Manages Secret Manager secrets',
+    'parameters': {
+    "type": "object",
+    "properties": {
+        "action": {
+            "type": "string",
+            "enum": [
+                "list",
+                "get",
+                "create",
+                "rotate"
+            ]
+        },
+        "secret_name": {
+            "type": "string"
+        },
+        "value": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "action",
+        "secret_name",
+        "value"
+    ]
+},
+    'returns': {
+    "success": "boolean",
+    "secret_version": "string"
+}
+}
+
+
+def execute(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Executes the manage_secrets tool.
+
+    Args:
+        params: The parameters for the tool as defined in TOOL_SCHEMA.
+
+    Returns:
+        The result of the tool execution as defined in TOOL_SCHEMA.
+    """
+    # TODO: Implement tool logic
+    pass

--- a/build_agents.py
+++ b/build_agents.py
@@ -1,0 +1,105 @@
+import os
+import yaml
+import json
+
+def create_agent(name, model, description, instruction, tools, directory):
+    agent_data = {
+        "name": name,
+        "model": model,
+        "description": description,
+        "instruction": instruction,
+        "tools": tools
+    }
+
+    os.makedirs(directory, exist_ok=True)
+    with open(os.path.join(directory, "agent.yaml"), "w") as f:
+        yaml.dump(agent_data, f, sort_keys=False)
+
+def create_tool(directory, tool_name, accepts, returns, desc):
+    os.makedirs(directory, exist_ok=True)
+    schema_str = f"TOOL_SCHEMA = {{\n    'description': '{desc}',\n    'parameters': {json.dumps(accepts, indent=4)},\n    'returns': {json.dumps(returns, indent=4)}\n}}\n"
+    content = f'''"""
+{desc}
+"""
+from typing import Dict, Any
+
+{schema_str}
+
+def execute(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Executes the {tool_name} tool.
+
+    Args:
+        params: The parameters for the tool as defined in TOOL_SCHEMA.
+
+    Returns:
+        The result of the tool execution as defined in TOOL_SCHEMA.
+    """
+    # TODO: Implement tool logic
+    pass
+'''
+    with open(os.path.join(directory, f"{tool_name}.py"), "w") as f:
+        f.write(content)
+
+
+# --- Courier ---
+courier_dir = "agents/courier"
+create_agent(
+    "Courier", "gemini-2.0-flash",
+    "Communications agent handling email, calendar, tasks, notifications, and meeting notes",
+    "You are Courier, the communications nerve center of Gravix. You manage all Gmail operations (classify, compose, summarize), Google Calendar (create events, check availability), Google Tasks (create, complete, organize), FCM push notifications, and Google Meet transcript processing. You learn email templates from patterns and auto-tag communications to client profiles.",
+    ["email_classify", "email_compose", "calendar_manage", "task_manage", "send_notification", "learn_templates", "process_meeting"],
+    courier_dir
+)
+t_dir = os.path.join(courier_dir, "tools")
+create_tool(t_dir, "email_classify", {"type": "object", "properties": {"subject": {"type": "string"}, "from_addr": {"type": "string"}, "snippet": {"type": "string"}}, "required": ["subject", "from_addr", "snippet"]}, {"category": "string", "urgency": "string", "confidence": "number"}, "Classifies email into categories: client, action-required, invoice, newsletter, personal")
+create_tool(t_dir, "email_compose", {"type": "object", "properties": {"to": {"type": "string"}, "subject_hint": {"type": "string"}, "context": {"type": "string"}, "tone": {"type": "string"}}, "required": ["to", "subject_hint", "context", "tone"]}, {"subject": "string", "body": "string", "suggested_attachments": "array"}, "Drafts email using context and templates")
+create_tool(t_dir, "calendar_manage", {"type": "object", "properties": {"action": {"type": "string", "enum": ["create", "update", "query"]}, "event_data": {"type": "object"}}, "required": ["action", "event_data"]}, {"success": "boolean", "event_id": "string", "events": "array"}, "Creates, updates, or queries calendar events")
+create_tool(t_dir, "task_manage", {"type": "object", "properties": {"action": {"type": "string", "enum": ["create", "complete", "list"]}, "task_data": {"type": "object"}}, "required": ["action", "task_data"]}, {"success": "boolean", "task_id": "string", "tasks": "array"}, "Creates or completes Google Tasks")
+create_tool(t_dir, "send_notification", {"type": "object", "properties": {"title": {"type": "string"}, "body": {"type": "string"}, "data": {"type": "object"}, "topic": {"type": "string"}}, "required": ["title", "body", "data", "topic"]}, {"sent": "boolean", "message_id": "string"}, "Sends FCM push notification")
+create_tool(t_dir, "learn_templates", {"type": "object", "properties": {"emails": {"type": "array", "items": {"type": "object", "properties": {"subject": {"type": "string"}, "body": {"type": "string"}}}}}, "required": ["emails"]}, {"templates": "array"}, "Analyzes sent emails for patterns and creates templates")
+create_tool(t_dir, "process_meeting", {"type": "object", "properties": {"transcript": {"type": "string"}, "attendees": {"type": "array", "items": {"type": "string"}}}, "required": ["transcript", "attendees"]}, {"summary": "string", "action_items": "array", "decisions": "array", "follow_ups": "array"}, "Processes meeting transcript and extracts action items")
+
+# --- Analyst ---
+analyst_dir = "agents/analyst"
+create_agent(
+    "Analyst", "gemini-2.0-flash",
+    "Data science agent that executes notebooks, analyzes data, and generates insights",
+    "You are Analyst, the data science agent of Gravix. You execute Jupyter notebooks via Cloud Run, analyze financial data, health trends, and business metrics. You can run stock analysis, portfolio optimization, and custom data pipelines.",
+    ["execute_notebook", "analyze_data", "format_results"],
+    analyst_dir
+)
+t_dir = os.path.join(analyst_dir, "tools")
+create_tool(t_dir, "execute_notebook", {"type": "object", "properties": {"notebook": {"type": "string"}, "parameters": {"type": "object"}}, "required": ["notebook", "parameters"]}, {"results": "object", "chart_urls": "array", "execution_time": "number"}, "Triggers Cloud Run notebook execution")
+create_tool(t_dir, "analyze_data", {"type": "object", "properties": {"data": {"type": "object"}, "analysis_type": {"type": "string"}, "question": {"type": "string"}}, "required": ["data", "analysis_type", "question"]}, {"analysis": "string", "insights": "array", "recommendations": "array"}, "General data analysis using Gemini")
+create_tool(t_dir, "format_results", {"type": "object", "properties": {"raw_results": {"type": "object"}, "format": {"type": "string", "enum": ["table", "chart", "summary"]}}, "required": ["raw_results", "format"]}, {"formatted": "object", "visualization_type": "string"}, "Formats analysis results for display")
+
+# --- Builder ---
+builder_dir = "agents/builder"
+create_agent(
+    "Builder", "gemini-2.0-flash",
+    "Development agent that extracts code patterns, generates code, and manages Jules tasks",
+    "You are Builder, the development agent of Gravix. You analyze merged PRs for reusable patterns, generate code snippets, and create Jules tasks for autonomous development. You maintain a pattern library and suggest refactors.",
+    ["extract_patterns", "generate_code", "create_jules_task"],
+    builder_dir
+)
+t_dir = os.path.join(builder_dir, "tools")
+create_tool(t_dir, "extract_patterns", {"type": "object", "properties": {"pr_files": {"type": "array", "items": {"type": "object", "properties": {"filename": {"type": "string"}, "patch": {"type": "string"}}}}}, "required": ["pr_files"]}, {"patterns": "array"}, "Analyzes code changes for reusable patterns")
+create_tool(t_dir, "generate_code", {"type": "object", "properties": {"spec": {"type": "string"}, "language": {"type": "string"}, "patterns_to_use": {"type": "array", "items": {"type": "string"}}}, "required": ["spec", "language", "patterns_to_use"]}, {"code": "string", "files": "array", "explanation": "string"}, "Generates code based on spec and existing patterns")
+create_tool(t_dir, "create_jules_task", {"type": "object", "properties": {"title": {"type": "string"}, "prompt": {"type": "string"}, "branch": {"type": "string"}}, "required": ["title", "prompt", "branch"]}, {"session_id": "string", "status": "string"}, "Creates a Jules task for autonomous execution")
+
+# --- Forge ---
+forge_dir = "agents/forge"
+create_agent(
+    "Forge", "gemini-2.0-flash",
+    "DevOps agent managing secrets, IAM, API configuration, and infrastructure",
+    "You are Forge, the DevOps agent of Gravix. You manage Google Cloud infrastructure: Secret Manager for credential rotation, IAM for access control, API configuration and restrictions, and service account management. You auto-detect API changes and update configurations.",
+    ["manage_secrets", "manage_iam", "configure_apis"],
+    forge_dir
+)
+t_dir = os.path.join(forge_dir, "tools")
+create_tool(t_dir, "manage_secrets", {"type": "object", "properties": {"action": {"type": "string", "enum": ["list", "get", "create", "rotate"]}, "secret_name": {"type": "string"}, "value": {"type": "string"}}, "required": ["action", "secret_name", "value"]}, {"success": "boolean", "secret_version": "string"}, "Manages Secret Manager secrets")
+create_tool(t_dir, "manage_iam", {"type": "object", "properties": {"action": {"type": "string", "enum": ["list_roles", "add_role", "remove_role"]}, "member": {"type": "string"}, "role": {"type": "string"}}, "required": ["action", "member", "role"]}, {"success": "boolean", "current_roles": "array"}, "Manages IAM roles and service accounts")
+create_tool(t_dir, "configure_apis", {"type": "object", "properties": {"action": {"type": "string", "enum": ["list", "enable", "restrict"]}, "api_name": {"type": "string"}, "restrictions": {"type": "array", "items": {"type": "string"}}}, "required": ["action", "api_name", "restrictions"]}, {"success": "boolean", "status": "string"}, "Manages API enablement and key restrictions")
+
+print("Generated.")


### PR DESCRIPTION
This PR creates the necessary structures for four Vertex AI ADK agents: Courier, Analyst, Builder, and Forge.

- Courier: Added `agents/courier/agent.yaml` and 7 tools (classify, compose, calendar, tasks, notifications, templates, meetings).
- Analyst: Added `agents/analyst/agent.yaml` and 3 tools (execute_notebook, analyze_data, format_results).
- Builder: Added `agents/builder/agent.yaml` and 3 tools (extract_patterns, generate_code, create_jules_task).
- Forge: Added `agents/forge/agent.yaml` and 3 tools (manage_secrets, manage_iam, configure_apis).

All tool files include correctly formatted `TOOL_SCHEMA` dicts, proper type hinting, and docstrings. Dependencies have been minimized per the prompt constraints. Vitest successfully passed.

---
*PR created automatically by Jules for task [526945358511658479](https://jules.google.com/task/526945358511658479) started by @JClouddd*