### PR TITLE
feat: Create ADK proxy layer for Agent Engine routing

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,3 @@
+# ADK Agent Engine (set when deployed)
+AGENT_ENGINE_URL=
+USE_ADK_AGENTS=false

--- a/patch_agentEngine.js
+++ b/patch_agentEngine.js
@@ -1,0 +1,5 @@
+const fs = require('fs');
+const file = 'src/lib/agentEngine.js';
+let data = fs.readFileSync(file, 'utf8');
+data = "import crypto from 'crypto';\n" + data;
+fs.writeFileSync(file, data);

--- a/src/app/api/agents/invoke/[name]/route.js
+++ b/src/app/api/agents/invoke/[name]/route.js
@@ -1,0 +1,43 @@
+import { routeToAgent, listAgentTools } from "@/lib/agentEngine";
+
+export async function POST(request, { params }) {
+  try {
+    const { name } = params;
+    const body = await request.json();
+    const { message, context = {} } = body;
+
+    if (!message) {
+      return Response.json(
+        { error: "message is required" },
+        { status: 400 }
+      );
+    }
+
+    const response = await routeToAgent(message, name, context);
+    return Response.json(response);
+  } catch (error) {
+    console.error(`[/api/agents/invoke/${params.name}]`, error);
+    return Response.json(
+      { error: error.message || "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET(request, { params }) {
+  try {
+    const { name } = params;
+    const tools = await listAgentTools(name);
+
+    return Response.json({
+      agent: name,
+      tools
+    });
+  } catch (error) {
+    console.error(`[/api/agents/invoke/${params.name}] GET`, error);
+    return Response.json(
+      { error: error.message || "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/agents/invoke/__tests__/route.test.js
+++ b/src/app/api/agents/invoke/__tests__/route.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST, GET } from '../[name]/route';
+import { routeToAgent, listAgentTools } from '@/lib/agentEngine';
+
+vi.mock('@/lib/agentEngine', () => ({
+  routeToAgent: vi.fn(),
+  listAgentTools: vi.fn()
+}));
+
+describe('Agent Invoke API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('POST /api/agents/invoke/[name]', () => {
+    it('returns 400 if message is missing', async () => {
+      const req = {
+        json: async () => ({ context: {} })
+      };
+
+      const response = await POST(req, { params: { name: 'scholar' } });
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toBe('message is required');
+    });
+
+    it('calls routeToAgent and returns response', async () => {
+      routeToAgent.mockResolvedValue({ status: 'ok', response: 'test response' });
+
+      const req = {
+        json: async () => ({ message: 'hello', context: { foo: 'bar' } })
+      };
+
+      const response = await POST(req, { params: { name: 'scholar' } });
+      const data = await response.json();
+
+      expect(routeToAgent).toHaveBeenCalledWith('hello', 'scholar', { foo: 'bar' });
+      expect(data.response).toBe('test response');
+    });
+
+    it('handles errors gracefully', async () => {
+      routeToAgent.mockRejectedValue(new Error('Test error'));
+
+      const req = {
+        json: async () => ({ message: 'hello' })
+      };
+
+      const response = await POST(req, { params: { name: 'scholar' } });
+      expect(response.status).toBe(500);
+      const data = await response.json();
+      expect(data.error).toBe('Test error');
+    });
+  });
+
+  describe('GET /api/agents/invoke/[name]', () => {
+    it('returns agent tools', async () => {
+      listAgentTools.mockResolvedValue([{ name: 'tool1' }]);
+
+      const req = {};
+
+      const response = await GET(req, { params: { name: 'scholar' } });
+      const data = await response.json();
+
+      expect(listAgentTools).toHaveBeenCalledWith('scholar');
+      expect(data.agent).toBe('scholar');
+      expect(data.tools).toEqual([{ name: 'tool1' }]);
+    });
+
+    it('handles errors gracefully', async () => {
+      listAgentTools.mockRejectedValue(new Error('Test error'));
+
+      const req = {};
+
+      const response = await GET(req, { params: { name: 'scholar' } });
+      expect(response.status).toBe(500);
+      const data = await response.json();
+      expect(data.error).toBe('Test error');
+    });
+  });
+});

--- a/src/lib/agentEngine.js
+++ b/src/lib/agentEngine.js
@@ -1,0 +1,159 @@
+import crypto from 'crypto';
+import { GoogleAuth } from 'google-auth-library';
+import { generate } from '@/lib/geminiClient';
+import registry from '@/../agents/registry.json';
+
+const AGENT_ENGINE_URL = process.env.AGENT_ENGINE_URL;
+const USE_ADK = process.env.USE_ADK_AGENTS === 'true';
+
+/**
+ * Dual-mode agent architecture proxy.
+ * Routes requests to either the deployed Agent Engine or falls back to the native Gemini implementation.
+ */
+
+/**
+ * Routes a message to a specific agent using either ADK Agent Engine or local fallback.
+ * @param {string} message The user request message.
+ * @param {string} [agentName=null] The name of the specific agent to invoke.
+ * @param {Object} [context={}] Additional context to pass.
+ * @returns {Promise<Object>} The agent response.
+ */
+export async function routeToAgent(message, agentName = null, context = {}) {
+  if (!USE_ADK) {
+    // Fall back to existing Gemini wrapper logic
+    let systemPrompt = `You are ${agentName || "an AI agent"}, a specialist agent in Gravix.`;
+    let complexity = "flash";
+    let grounded = false;
+
+    if (agentName) {
+      const agentConfig = registry.agents[agentName];
+      if (agentConfig) {
+        systemPrompt = `You are ${agentConfig.displayName}, a specialist agent in Gravix. ${agentConfig.role}`;
+      }
+
+      if (agentName === 'scholar') {
+        complexity = 'pro';
+        grounded = true;
+      } else if (agentName === 'sentinel') {
+        grounded = true;
+      }
+    }
+
+    const result = await generate({
+      prompt: message,
+      systemPrompt,
+      complexity,
+      grounded,
+    });
+
+    return {
+      agent: agentName || 'unknown',
+      status: 'ok',
+      response: result.text,
+      model: result.model,
+      tokens: result.tokens,
+      source: 'gemini_fallback'
+    };
+  } else {
+    // Call ADK Agent Engine
+    if (!AGENT_ENGINE_URL) {
+      throw new Error("AGENT_ENGINE_URL is not set");
+    }
+
+    const auth = new GoogleAuth();
+    const client = await auth.getIdTokenClient(AGENT_ENGINE_URL);
+
+    const url = agentName
+      ? `${AGENT_ENGINE_URL}/agents/${agentName}/invoke`
+      : `${AGENT_ENGINE_URL}/agents/invoke`;
+
+    const sessionId = crypto.randomUUID();
+
+    const res = await client.request({
+      url,
+      method: 'POST',
+      data: {
+        message,
+        sessionId,
+        context
+      }
+    });
+
+    return {
+      ...res.data,
+      source: 'agent_engine'
+    };
+  }
+}
+
+/**
+ * Retrieves the status of all available agents.
+ * @returns {Promise<Array<Object>>} List of agent statuses.
+ */
+export async function getAgentStatus() {
+  if (!USE_ADK) {
+    return Object.entries(registry.agents).map(([id, data]) => ({
+      id,
+      name: data.displayName,
+      status: "active",
+      source: 'registry_fallback'
+    }));
+  } else {
+    if (!AGENT_ENGINE_URL) {
+      throw new Error("AGENT_ENGINE_URL is not set");
+    }
+
+    const auth = new GoogleAuth();
+    const client = await auth.getIdTokenClient(AGENT_ENGINE_URL);
+
+    const res = await client.request({
+      url: `${AGENT_ENGINE_URL}/agents/status`,
+      method: 'GET'
+    });
+
+    return res.data;
+  }
+}
+
+/**
+ * Lists the available tools for a specific agent.
+ * @param {string} agentName The name of the agent.
+ * @returns {Promise<Array<Object>>} List of tools.
+ */
+export async function listAgentTools(agentName) {
+  if (!USE_ADK) {
+    // Mock data based on agent name
+    const tools = [];
+    if (agentName === 'forge') {
+      tools.push({ name: 'systemStatus', description: 'Get system status' });
+      tools.push({ name: 'costs', description: 'Get system costs' });
+    } else if (agentName === 'scholar') {
+      tools.push({ name: 'queryKnowledge', description: 'Query knowledge base' });
+    } else if (agentName === 'analyst') {
+      tools.push({ name: 'executeColab', description: 'Execute colab notebook' });
+    } else if (agentName === 'courier') {
+      tools.push({ name: 'emailInbox', description: 'Check email inbox' });
+    } else if (agentName === 'builder') {
+      tools.push({ name: 'julesTasks', description: 'Check jules tasks' });
+    } else if (agentName === 'sentinel') {
+      tools.push({ name: 'costSummary', description: 'Get cost summary' });
+      tools.push({ name: 'costBreakdown', description: 'Get cost breakdown' });
+    }
+
+    return tools;
+  } else {
+    if (!AGENT_ENGINE_URL) {
+      throw new Error("AGENT_ENGINE_URL is not set");
+    }
+
+    const auth = new GoogleAuth();
+    const client = await auth.getIdTokenClient(AGENT_ENGINE_URL);
+
+    const res = await client.request({
+      url: `${AGENT_ENGINE_URL}/agents/${agentName}/tools`,
+      method: 'GET'
+    });
+
+    return res.data;
+  }
+}


### PR DESCRIPTION
This PR creates the ADK proxy layer (`src/lib/agentEngine.js`) to support a dual-mode architecture that routes agent invocations either to a deployed ADK Agent Engine or falls back to the native Gemini implementation depending on the `USE_ADK_AGENTS` environment flag. It includes the dynamic API route (`src/app/api/agents/invoke/[name]/route.js`) to handle these invocations, adds the `google-auth-library` dependency for authentication with the remote engine, and includes test coverage to verify route functionality.

---
*PR created automatically by Jules for task [16718022623202770017](https://jules.google.com/task/16718022623202770017) started by @JClouddd*