### PR TITLE
Migrate remaining API routes to Firebase Admin SDK

### DIFF
--- a/src/app/api/agents/builder/patterns/route.js
+++ b/src/app/api/agents/builder/patterns/route.js
@@ -1,12 +1,11 @@
 import { NextResponse } from "next/server";
-import { db } from "@/lib/firebase";
-import { collection, getDocs, setDoc, doc, serverTimestamp } from "firebase/firestore";
+import { adminDb } from "@/lib/firebaseAdmin";
 import { generate } from "@/lib/geminiClient";
 
 export async function GET() {
   try {
-    const patternsRef = collection(db, "code_patterns");
-    const snapshot = await getDocs(patternsRef);
+    const patternsRef = adminDb.collection("code_patterns");
+    const snapshot = await patternsRef.get();
     const patterns = snapshot.docs.map(doc => doc.data());
     return NextResponse.json({ patterns });
   } catch (error) {
@@ -91,9 +90,9 @@ ${changesText.slice(0, 50000)} // Limit to avoid token overflow`;
     if (parsedData.patterns && Array.isArray(parsedData.patterns)) {
       for (const pattern of parsedData.patterns) {
         const docId = pattern.name.toLowerCase().replace(/[^a-z0-9]/g, '-');
-        await setDoc(doc(db, "code_patterns", docId), {
+        await adminDb.collection("code_patterns").doc(docId).set( {
           ...pattern,
-          updatedAt: serverTimestamp()
+          updatedAt: new Date()
         });
         storedCount++;
       }

--- a/src/app/api/agents/conductor/analyze/route.js
+++ b/src/app/api/agents/conductor/analyze/route.js
@@ -1,12 +1,12 @@
-import { collection, query, orderBy, limit, getDocs, addDoc, doc, updateDoc } from "firebase/firestore";
-import { db } from "@/lib/firebase";
+
+import { adminDb } from "@/lib/firebaseAdmin";
 import { structuredGenerate } from "@/lib/geminiClient";
 
 export async function POST(request) {
   try {
-    const logsRef = collection(db, "agent_routing_log");
-    const q = query(logsRef, orderBy("timestamp", "desc"), limit(100));
-    const querySnapshot = await getDocs(q);
+    const logsRef = adminDb.collection("agent_routing_log");
+    const q = logsRef.orderBy("timestamp", "desc").limit(100);
+    const querySnapshot = await q.get();
 
     const logs = [];
     querySnapshot.forEach((doc) => {
@@ -61,11 +61,11 @@ export async function POST(request) {
       console.error("[conductor/analyze] Error parsing gemini response", e);
     }
 
-    const proposalsRef = collection(db, "agent_proposals");
+    const proposalsRef = adminDb.collection("agent_proposals");
     const timestamp = new Date().toISOString();
 
     for (const proposal of generatedProposals) {
-      await addDoc(proposalsRef, {
+      await proposalsRef.add( {
         ...proposal,
         status: "pending",
         timestamp,
@@ -81,9 +81,9 @@ export async function POST(request) {
 
 export async function GET(request) {
   try {
-    const proposalsRef = collection(db, "agent_proposals");
-    const q = query(proposalsRef, orderBy("timestamp", "desc"));
-    const querySnapshot = await getDocs(q);
+    const proposalsRef = adminDb.collection("agent_proposals");
+    const q = proposalsRef.orderBy("timestamp", "desc");
+    const querySnapshot = await q.get();
 
     const proposals = [];
     querySnapshot.forEach((doc) => {
@@ -104,8 +104,8 @@ export async function PUT(request) {
       return Response.json({ error: "Missing id or status" }, { status: 400 });
     }
 
-    const proposalDoc = doc(db, "agent_proposals", id);
-    await updateDoc(proposalDoc, { status });
+    const proposalDoc = adminDb.collection("agent_proposals").doc(id);
+    await proposalDoc.update( { status });
 
     return Response.json({ success: true, id, status });
   } catch (error) {

--- a/src/app/api/agents/courier/templates/route.js
+++ b/src/app/api/agents/courier/templates/route.js
@@ -1,13 +1,12 @@
 import { NextResponse } from "next/server";
-import { db } from "@/lib/firebase";
-import { collection, getDocs, setDoc, doc, getDoc, serverTimestamp } from "firebase/firestore";
+import { adminDb } from "@/lib/firebaseAdmin";
 import { generate } from "@/lib/geminiClient";
 import { googleApiRequest, refreshAccessToken } from "@/lib/googleAuth";
 
 export async function GET() {
   try {
-    const templatesRef = collection(db, "email_templates");
-    const snapshot = await getDocs(templatesRef);
+    const templatesRef = adminDb.collection("email_templates");
+    const snapshot = await templatesRef.get();
     const templates = snapshot.docs.map(doc => doc.data());
     return NextResponse.json({ templates });
   } catch (error) {
@@ -19,8 +18,8 @@ export async function GET() {
 export async function POST() {
   try {
     // 1. Get OAuth token from Firestore
-    const oauthDoc = await getDoc(doc(db, "settings", "google_oauth"));
-    if (!oauthDoc.exists()) {
+    const oauthDoc = await adminDb.collection("settings").doc("google_oauth").get();
+    if (!oauthDoc.exists) {
       return NextResponse.json({ error: "Google OAuth not configured" }, { status: 400 });
     }
 
@@ -122,9 +121,9 @@ ${emailsCombinedText.slice(0, 50000)} // Limit to avoid token overflow`;
     if (parsedData.templates && Array.isArray(parsedData.templates)) {
       for (const template of parsedData.templates) {
         const docId = template.name.toLowerCase().replace(/[^a-z0-9]/g, '-');
-        await setDoc(doc(db, "email_templates", docId), {
+        await adminDb.collection("email_templates").doc(docId).set( {
           ...template,
-          updatedAt: serverTimestamp()
+          updatedAt: new Date()
         });
         storedCount++;
       }

--- a/src/app/api/agents/route/route.js
+++ b/src/app/api/agents/route/route.js
@@ -1,7 +1,7 @@
 import { structuredGenerate, generate } from "@/lib/geminiClient";
 import { logUsage } from "@/lib/costTracker";
-import { collection, addDoc } from "firebase/firestore";
-import { db } from "@/lib/firebase";
+
+import { adminDb } from "@/lib/firebaseAdmin";
 
 /**
  * POST /api/agents/route
@@ -71,7 +71,7 @@ Choose the best agent and explain your reasoning.`,
 
     // Log routing decision to Firestore for Conductor analysis
     try {
-      await addDoc(collection(db, "agent_routing_log"), {
+      await adminDb.collection("agent_routing_log").add( {
         message: message.substring(0, 100),
         selectedAgent: decision.agent,
         timestamp: new Date().toISOString()

--- a/src/app/api/agents/sentinel/analyze/route.js
+++ b/src/app/api/agents/sentinel/analyze/route.js
@@ -1,18 +1,17 @@
 import { NextResponse } from "next/server";
-import { db } from "@/lib/firebase";
-import { collection, query, orderBy, limit, getDocs, addDoc } from "firebase/firestore";
+import { adminDb } from "@/lib/firebaseAdmin";
+
 import { generate } from "@/lib/geminiClient";
 
 export async function POST(request) {
   try {
     // Read last 30 health check results from Firestore collection health_checks
-    const checksRef = collection(db, "health_checks");
-    const q = query(checksRef, orderBy("timestamp", "desc"), limit(30));
-    const snapshot = await getDocs(q);
+    const checksRef = adminDb.collection("health_checks");
+    const q = checksRef.orderBy("timestamp", "desc").limit(30);
+    const snapshot = await q.get();
 
     const healthData = [];
     snapshot.forEach(doc => healthData.push(doc.data()));
-
 
     // Prepare prompt
     const prompt = `Analyze these health check results looking for cost patterns, error frequency, and latency trends. If you detect anomalies, propose monitoring rules.
@@ -33,10 +32,9 @@ Return JSON: { anomalies: [{ type, description, severity }], proposedRules: [{ c
       analysisResult = { anomalies: [], proposedRules: [] };
     }
 
-
     // Store proposals in Firestore collection rule_proposals
-    const proposalsRef = collection(db, "rule_proposals");
-    const docRef = await addDoc(proposalsRef, {
+    const proposalsRef = adminDb.collection("rule_proposals");
+    const docRef = await proposalsRef.add( {
       ...analysisResult,
       createdAt: new Date().toISOString()
     });
@@ -55,9 +53,9 @@ Return JSON: { anomalies: [{ type, description, severity }], proposedRules: [{ c
 
 export async function GET() {
   try {
-    const proposalsRef = collection(db, "rule_proposals");
-    const q = query(proposalsRef, orderBy("createdAt", "desc"), limit(10));
-    const snapshot = await getDocs(q);
+    const proposalsRef = adminDb.collection("rule_proposals");
+    const q = proposalsRef.orderBy("createdAt", "desc").limit(10);
+    const snapshot = await q.get();
 
     const proposals = [];
     snapshot.forEach(doc => {

--- a/src/app/api/agents/sentinel/rules/route.js
+++ b/src/app/api/agents/sentinel/rules/route.js
@@ -1,26 +1,21 @@
 import { NextResponse } from "next/server";
-import { db } from "@/lib/firebase";
-import { collection, addDoc, query, where, orderBy, getDocs, doc, updateDoc } from "firebase/firestore";
+import { adminDb } from "@/lib/firebaseAdmin";
 
 export async function GET() {
   try {
-    const rulesRef = collection(db, "sentinel_rules");
-    const q = query(
-      rulesRef,
-      where("active", "==", true),
-      orderBy("createdAt", "asc") // or desc, let's use asc as it's default for simple sort if not specified, but let's just make sure we sort by createdAt
-    );
+    const rulesRef = adminDb.collection("sentinel_rules");
+    const q = rulesRef.where("active", "==", true).orderBy("createdAt", "asc") // or desc, let's use asc as it's default for simple sort if not specified, but let's just make sure we sort by createdAt;
 
     // Firestore might require an index for where("active", "==", true) + orderBy("createdAt", "asc").
     // As a fallback to avoid index errors, we can just get active rules and sort in memory if needed,
     // but typically simple equality + orderBy works if indexed, or we can just query all and filter/sort.
     // Given the "No external dependencies" and potential index issues in a generic test environment,
     // let's do query all and filter/sort in memory to be perfectly safe, or just use simple query.
-    // Actually, simple query(rulesRef, orderBy("createdAt", "asc")) and then filter active:true is safest without index setup.
+    // Actually, simple rulesRef.orderBy("createdAt", "asc")) and then filter active:true is safest without index setup.
 
     // Let's just try simple orderBy first, filter in memory
-    const simpleQ = query(rulesRef, orderBy("createdAt", "asc"));
-    const snapshot = await getDocs(simpleQ);
+    const simpleQ = rulesRef.orderBy("createdAt", "asc");
+    const snapshot = await simpleQ.get();
 
     const rules = [];
     snapshot.forEach((doc) => {
@@ -57,8 +52,8 @@ export async function POST(request) {
       createdAt: new Date().toISOString()
     };
 
-    const rulesRef = collection(db, "sentinel_rules");
-    const docRef = await addDoc(rulesRef, newRule);
+    const rulesRef = adminDb.collection("sentinel_rules");
+    const docRef = await rulesRef.add( newRule);
 
     return NextResponse.json({ created: true, ruleId: docRef.id });
   } catch (error) {
@@ -75,8 +70,8 @@ export async function DELETE(request) {
       return NextResponse.json({ error: "Missing ruleId" }, { status: 400 });
     }
 
-    const ruleRef = doc(db, "sentinel_rules", ruleId);
-    await updateDoc(ruleRef, { active: false });
+    const ruleRef = adminDb.collection("sentinel_rules").doc(ruleId);
+    await ruleRef.update( { active: false });
 
     return NextResponse.json({ deleted: true, ruleId });
   } catch (error) {

--- a/src/app/api/auth/callback/route.js
+++ b/src/app/api/auth/callback/route.js
@@ -1,6 +1,6 @@
 import { exchangeCode } from "@/lib/googleAuth";
-import { getFirestore, doc, setDoc } from "firebase/firestore";
-import { db } from "@/lib/firebase";
+
+import { adminDb } from "@/lib/firebaseAdmin";
 
 /**
  * GET /api/auth/callback
@@ -31,7 +31,7 @@ export async function GET(request) {
     const tokens = await exchangeCode(code, redirectUri);
 
     // Store tokens in Firestore (will be encrypted at rest by Firebase)
-    await setDoc(doc(db, "settings", "google_oauth"), {
+    await adminDb.collection("settings").doc("google_oauth").set( {
       accessToken: tokens.access_token,
       refreshToken: tokens.refresh_token,
       expiresAt: Date.now() + (tokens.expires_in * 1000),

--- a/src/app/api/automation/client-onboard/route.js
+++ b/src/app/api/automation/client-onboard/route.js
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { structuredGenerate, generate } from "@/lib/geminiClient";
-import { db } from "@/lib/firebase";
-import { doc, getDoc, collection, addDoc } from "firebase/firestore";
+import { adminDb } from "@/lib/firebaseAdmin";
 
 export async function POST(request) {
   try {
@@ -17,8 +16,8 @@ export async function POST(request) {
     let welcomeDrafted = false;
 
     // 1. Fetch OAuth token
-    const oauthDoc = await getDoc(doc(db, "settings", "google_oauth"));
-    if (!oauthDoc.exists() || !oauthDoc.data().access_token) {
+    const oauthDoc = await adminDb.collection("settings").doc("google_oauth").get();
+    if (!oauthDoc.exists || !oauthDoc.data().access_token) {
       return NextResponse.json({ error: "Google Workspace not connected (no OAuth token)" }, { status: 401 });
     }
     const accessToken = oauthDoc.data().access_token;
@@ -133,7 +132,7 @@ export async function POST(request) {
           systemPrompt: "You are the Gravix Courier agent, drafting professional client communications."
         });
 
-        await addDoc(collection(db, "email_drafts"), {
+        await adminDb.collection("email_drafts").add( {
           to: clientEmail,
           subject: `Welcome to Gravix, ${clientName}!`,
           body: emailResponse.text,

--- a/src/app/api/automation/email-pipeline/route.js
+++ b/src/app/api/automation/email-pipeline/route.js
@@ -1,5 +1,5 @@
-import { getFirestore, doc, getDoc, collection, addDoc, updateDoc } from "firebase/firestore";
-import { db } from "@/lib/firebase";
+
+import { adminDb } from "@/lib/firebaseAdmin";
 import { refreshAccessToken } from "@/lib/googleAuth";
 
 export async function POST(request) {
@@ -24,15 +24,15 @@ export async function POST(request) {
       // 1. Task creation for action-required or high urgency
       if (category === "action-required" || urgency === "high") {
         if (!accessToken) {
-          const tokensDoc = await getDoc(doc(db, "settings", "google_oauth"));
-          if (tokensDoc.exists()) {
+          const tokensDoc = await adminDb.collection("settings").doc("google_oauth").get();
+          if (tokensDoc.exists) {
             const tokens = tokensDoc.data();
             accessToken = tokens.accessToken;
 
             if (Date.now() > tokens.expiresAt) {
               const refreshed = await refreshAccessToken(tokens.refreshToken);
               accessToken = refreshed.access_token;
-              await updateDoc(doc(db, "settings", "google_oauth"), {
+              await adminDb.collection("settings").doc("google_oauth").update( {
                 accessToken: refreshed.access_token,
                 expiresAt: Date.now() + (refreshed.expires_in * 1000),
               });
@@ -63,7 +63,7 @@ export async function POST(request) {
       // 2. Client linkage
       if (category === "client") {
         try {
-          await addDoc(collection(db, "client_emails"), {
+          await adminDb.collection("client_emails").add( {
             emailId: id,
             from,
             matchedClient: from, // simplified for now
@@ -79,7 +79,7 @@ export async function POST(request) {
       const lowerSubject = (subject || "").toLowerCase();
       if (category === "invoice" || lowerSubject.includes("invoice") || lowerSubject.includes("receipt")) {
         try {
-          await addDoc(collection(db, "income_entries"), {
+          await adminDb.collection("income_entries").add( {
             from,
             subject,
             timestamp: new Date().toISOString(),

--- a/src/app/api/automation/meeting-pipeline/route.js
+++ b/src/app/api/automation/meeting-pipeline/route.js
@@ -1,5 +1,5 @@
-import { doc, getDoc, updateDoc, collection, addDoc } from "firebase/firestore";
-import { db } from "@/lib/firebase";
+
+import { adminDb } from "@/lib/firebaseAdmin";
 import { refreshAccessToken, googleApiRequest } from "@/lib/googleAuth";
 import { generate } from "@/lib/geminiClient";
 
@@ -15,8 +15,8 @@ export async function POST(request) {
     const { actionItems = [], followUps = [], decisions = [] } = analysis;
 
     // Get and manage OAuth tokens
-    const tokensDoc = await getDoc(doc(db, "settings", "google_oauth"));
-    if (!tokensDoc.exists()) {
+    const tokensDoc = await adminDb.collection("settings").doc("google_oauth").get();
+    if (!tokensDoc.exists) {
       return Response.json({ error: "Google Workspace not connected" }, { status: 401 });
     }
 
@@ -27,7 +27,7 @@ export async function POST(request) {
       try {
         const refreshed = await refreshAccessToken(tokens.refreshToken);
         accessToken = refreshed.access_token;
-        await updateDoc(doc(db, "settings", "google_oauth"), {
+        await adminDb.collection("settings").doc("google_oauth").update( {
           accessToken: refreshed.access_token,
           expiresAt: Date.now() + (refreshed.expires_in * 1000),
         });
@@ -111,7 +111,7 @@ export async function POST(request) {
       try {
         const decisionText = typeof decision === "string" ? decision : decision.decision;
         if (decisionText) {
-          await addDoc(collection(db, "meeting_decisions"), {
+          await adminDb.collection("meeting_decisions").add( {
             meetingId,
             decision: decisionText,
             timestamp: new Date().toISOString(),
@@ -140,7 +140,7 @@ export async function POST(request) {
          complexity: "flash"
       });
 
-      await addDoc(collection(db, "email_drafts"), {
+      await adminDb.collection("email_drafts").add( {
         meetingId,
         subject: `Meeting Summary: ${meetingId}`,
         body: generatedEmail,

--- a/src/app/api/automation/sentinel-check/route.js
+++ b/src/app/api/automation/sentinel-check/route.js
@@ -1,11 +1,10 @@
 import { NextResponse } from "next/server";
-import { db } from "@/lib/firebase";
-import { collection, query, where, getDocs, addDoc } from "firebase/firestore";
+import { adminDb } from "@/lib/firebaseAdmin";
+
 // Import health checks logic
 import { GET as getHealth } from "@/app/api/health/route";
 // Import analyze logic
 import { POST as runAnalyze } from "@/app/api/agents/sentinel/analyze/route";
-
 
 export async function POST(request) {
   try {
@@ -24,9 +23,9 @@ export async function POST(request) {
     }
 
     // 2. Fetch active rules
-    const rulesRef = collection(db, "sentinel_rules");
-    const q = query(rulesRef, where("active", "==", true));
-    const rulesSnapshot = await getDocs(q);
+    const rulesRef = adminDb.collection("sentinel_rules");
+    const q = rulesRef.where("active", "==", true);
+    const rulesSnapshot = await q.get();
     const rules = [];
     rulesSnapshot.forEach(doc => rules.push({ id: doc.id, ...doc.data() }));
 
@@ -69,8 +68,8 @@ export async function POST(request) {
         // Execute action (simulate FCM notification by writing to a notifications collection)
         console.log(`Sentinel rule triggered: ${condition} > ${threshold}. Action: ${action}`);
         try {
-          const notificationsRef = collection(db, "notifications");
-          await addDoc(notificationsRef, {
+          const notificationsRef = adminDb.collection("notifications");
+          await notificationsRef.add( {
             title: "Sentinel Alert",
             message: `Rule triggered: ${condition} exceeded threshold ${threshold}`,
             action: action,

--- a/src/app/api/calendar/events/route.js
+++ b/src/app/api/calendar/events/route.js
@@ -39,7 +39,7 @@ export async function GET() {
     const rawEvents = eventsResponse.items || eventsResponse || [];
 
     // Fetch clients to check for attendee matches
-    const clientsSnapshot = await getDocs(collection(db, "clients"));
+    const clientsSnapshot = await adminDb.collection("clients").get();
     const clientEmails = new Set();
     clientsSnapshot.forEach(doc => {
       const data = doc.data();

--- a/src/app/api/clients/[id]/billing/route.js
+++ b/src/app/api/clients/[id]/billing/route.js
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
-import { collection, doc, getDocs, addDoc, query, orderBy } from 'firebase/firestore';
-import { db } from '@/lib/firebase';
+
+import { adminDb } from "@/lib/firebaseAdmin";
 
 export async function GET(request, { params }) {
   try {
@@ -10,9 +10,9 @@ export async function GET(request, { params }) {
       return NextResponse.json({ error: "Client ID is required" }, { status: 400 });
     }
 
-    const billingRef = collection(db, 'clients', id, 'billing');
-    const q = query(billingRef, orderBy('date', 'desc'));
-    const snapshot = await getDocs(q);
+    const billingRef = adminDb.collection('clients').doc(id).collection('billing');
+    const q = billingRef.orderBy('date', 'desc');
+    const snapshot = await q.get();
 
     const entries = snapshot.docs.map(doc => ({
       id: doc.id,
@@ -46,8 +46,8 @@ export async function POST(request, { params }) {
        return NextResponse.json({ error: "Invalid type" }, { status: 400 });
     }
 
-    const billingRef = collection(db, 'clients', id, 'billing');
-    const newDocRef = await addDoc(billingRef, {
+    const billingRef = adminDb.collection('clients').doc(id).collection('billing');
+    const newDocRef = await billingRef.add( {
       description,
       amount: Number(amount),
       hours: hours ? Number(hours) : null,

--- a/src/app/api/clients/[id]/communications/route.js
+++ b/src/app/api/clients/[id]/communications/route.js
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
-import { collection, getDocs, query, where } from 'firebase/firestore';
-import { db } from '@/lib/firebase';
+
+import { adminDb } from "@/lib/firebaseAdmin";
 
 export async function GET(request, { params }) {
   try {
@@ -16,9 +16,9 @@ export async function GET(request, { params }) {
 
     // 1. Fetch client_emails
     try {
-      const emailsRef = collection(db, 'client_emails');
-      const emailsQuery = query(emailsRef, where('matchedClient', '==', id));
-      const emailsSnapshot = await getDocs(emailsQuery);
+      const emailsRef = adminDb.collection('client_emails');
+      const emailsQuery = emailsRef.where('matchedClient', '==', id);
+      const emailsSnapshot = await emailsQuery.get();
 
       emailsSnapshot.forEach(doc => {
         const data = doc.data();
@@ -38,10 +38,10 @@ export async function GET(request, { params }) {
 
     // 2. Fetch meeting_decisions
     try {
-      const meetingsRef = collection(db, 'meeting_decisions');
+      const meetingsRef = adminDb.collection('meeting_decisions');
       // Look for meetings related to this client
-      const meetingsQuery = query(meetingsRef, where('clientId', '==', id));
-      const meetingsSnapshot = await getDocs(meetingsQuery);
+      const meetingsQuery = meetingsRef.where('clientId', '==', id);
+      const meetingsSnapshot = await meetingsQuery.get();
 
       meetingsSnapshot.forEach(doc => {
         const data = doc.data();

--- a/src/app/api/costs/history/route.js
+++ b/src/app/api/costs/history/route.js
@@ -1,7 +1,6 @@
 import { logUsage, getUsageSummary } from "@/lib/costTracker";
-import { collection, query, where, getDocs, Timestamp } from "firebase/firestore";
 
-import { db as clientDb } from "@/lib/firebase";
+import { adminDb } from "@/lib/firebaseAdmin";
 
 export async function GET(request) {
   try {
@@ -18,13 +17,10 @@ export async function GET(request) {
     startDate.setDate(now.getDate() - daysToFetch);
     startDate.setHours(0, 0, 0, 0);
 
-    const usageRef = collection(clientDb, "api_usage");
-    const q = query(
-      usageRef,
-      where("timestamp", ">=", Timestamp.fromDate(startDate))
-    );
+    const usageRef = adminDb.collection("api_usage");
+    const q = usageRef.where("timestamp", ">=", startDate);
 
-    const querySnapshot = await getDocs(q);
+    const querySnapshot = await q.get();
 
     let totalSpend = 0;
     const historyMap = {};

--- a/src/app/api/email/summarize/route.js
+++ b/src/app/api/email/summarize/route.js
@@ -1,7 +1,7 @@
 import { refreshAccessToken, googleApiRequest } from "@/lib/googleAuth";
 import { generate } from "@/lib/geminiClient";
-import { doc, getDoc, updateDoc } from "firebase/firestore";
-import { db } from "@/lib/firebase";
+
+import { adminDb } from "@/lib/firebaseAdmin";
 
 export async function POST(request) {
   try {
@@ -13,8 +13,8 @@ export async function POST(request) {
     }
 
     // 1. Get OAuth tokens
-    const tokensDoc = await getDoc(doc(db, "settings", "google_oauth"));
-    if (!tokensDoc.exists()) {
+    const tokensDoc = await adminDb.collection("settings").doc("google_oauth").get();
+    if (!tokensDoc.exists) {
       return Response.json({ error: "Gmail is not connected." }, { status: 401 });
     }
 
@@ -26,7 +26,7 @@ export async function POST(request) {
       try {
         const refreshed = await refreshAccessToken(tokens.refreshToken);
         accessToken = refreshed.access_token;
-        await updateDoc(doc(db, "settings", "google_oauth"), {
+        await adminDb.collection("settings").doc("google_oauth").update( {
           accessToken: refreshed.access_token,
           expiresAt: Date.now() + (refreshed.expires_in * 1000),
         });

--- a/src/app/api/email/to-task/route.js
+++ b/src/app/api/email/to-task/route.js
@@ -1,6 +1,6 @@
 import { refreshAccessToken, googleApiRequest } from "@/lib/googleAuth";
-import { doc, getDoc, updateDoc } from "firebase/firestore";
-import { db } from "@/lib/firebase";
+
+import { adminDb } from "@/lib/firebaseAdmin";
 
 export async function POST(request) {
   try {
@@ -11,8 +11,8 @@ export async function POST(request) {
     }
 
     // 1. Get OAuth tokens
-    const tokensDoc = await getDoc(doc(db, "settings", "google_oauth"));
-    if (!tokensDoc.exists()) {
+    const tokensDoc = await adminDb.collection("settings").doc("google_oauth").get();
+    if (!tokensDoc.exists) {
       return Response.json({ error: "Google Workspace is not connected." }, { status: 401 });
     }
 
@@ -24,7 +24,7 @@ export async function POST(request) {
       try {
         const refreshed = await refreshAccessToken(tokens.refreshToken);
         accessToken = refreshed.access_token;
-        await updateDoc(doc(db, "settings", "google_oauth"), {
+        await adminDb.collection("settings").doc("google_oauth").update( {
           accessToken: refreshed.access_token,
           expiresAt: Date.now() + (refreshed.expires_in * 1000),
         });

--- a/src/app/api/health/history/route.js
+++ b/src/app/api/health/history/route.js
@@ -1,12 +1,11 @@
 import { NextResponse } from "next/server";
-import { db } from "@/lib/firebase";
-import { collection, addDoc, query, orderBy, limit, getDocs } from "firebase/firestore";
+import { adminDb } from "@/lib/firebaseAdmin";
 
 export async function GET() {
   try {
-    const checksRef = collection(db, "health_checks");
-    const q = query(checksRef, orderBy("timestamp", "desc"), limit(30));
-    const snapshot = await getDocs(q);
+    const checksRef = adminDb.collection("health_checks");
+    const q = checksRef.orderBy("timestamp", "desc").limit(30);
+    const snapshot = await q.get();
 
     const checks = [];
     let healthyCount = 0;
@@ -31,8 +30,8 @@ export async function GET() {
 export async function POST(request) {
   try {
     const data = await request.json();
-    const checksRef = collection(db, "health_checks");
-    await addDoc(checksRef, data);
+    const checksRef = adminDb.collection("health_checks");
+    await checksRef.add( data);
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error("Error writing health history:", error);

--- a/src/app/api/knowledge/crossref/route.js
+++ b/src/app/api/knowledge/crossref/route.js
@@ -1,5 +1,5 @@
-import { db } from "@/lib/firebase";
-import { collection, addDoc, getDocs, query, orderBy, limit } from "firebase/firestore";
+import { adminDb } from "@/lib/firebaseAdmin";
+
 import { structuredGenerate } from "@/lib/geminiClient";
 
 /**
@@ -130,7 +130,7 @@ ${existingKnowledgeContext}
     };
 
     try {
-      await addDoc(collection(db, "knowledge_crossrefs"), crossrefData);
+      await adminDb.collection("knowledge_crossrefs").add( crossrefData);
     } catch (dbErr) {
       console.warn("[knowledge/crossref] Failed to save to Firestore:", dbErr);
     }
@@ -148,13 +148,9 @@ ${existingKnowledgeContext}
  */
 export async function GET(request) {
   try {
-    const q = query(
-      collection(db, "knowledge_crossrefs"),
-      orderBy("createdAt", "desc"),
-      limit(20)
-    );
+    const q = adminDb.collection("knowledge_crossrefs").orderBy("createdAt", "desc").limit(20);
 
-    const querySnapshot = await getDocs(q);
+    const querySnapshot = await q.get();
     const results = querySnapshot.docs.map(doc => ({
       id: doc.id,
       ...doc.data()

--- a/src/app/api/notifications/send/route.js
+++ b/src/app/api/notifications/send/route.js
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
-import { db } from '@/lib/firebase';
-import { doc, getDoc } from 'firebase/firestore';
+import { adminDb } from "@/lib/firebaseAdmin";
+
 import crypto from 'crypto';
 
 /**
@@ -64,8 +64,8 @@ export async function POST(request) {
     }
 
     // 1. Get FCM Token from Firestore
-    const fcmDoc = await getDoc(doc(db, "settings", "fcm_token"));
-    if (!fcmDoc.exists() || !fcmDoc.data().token) {
+    const fcmDoc = await adminDb.collection("settings").doc("fcm_token").get();
+    if (!fcmDoc.exists || !fcmDoc.data().token) {
       return NextResponse.json({ error: 'No FCM token found. User might not have enabled notifications.' }, { status: 404 });
     }
     const fcmToken = fcmDoc.data().token;


### PR DESCRIPTION
Migrated all remaining `src/app/api` server routes to use the Firebase Admin SDK.

**Changes:**
1.  **Refactored 20 API Routes:** Updated files across agents, automation, clients, costs, email, health, knowledge, notifications, and auth to use `adminDb`.
2.  **Syntax Adjustments:** Replaced complex client SDK functions (`collection()`, `doc()`, `getDocs()`, `getDoc()`, `setDoc()`, `updateDoc()`, `addDoc()`) with the object-oriented Admin SDK syntax (e.g., `.collection().doc().get()`).
3.  **Timestamp Cleanup:** Swapped client-side `serverTimestamp()` or `Timestamp` imports for standard JavaScript `new Date()` objects, keeping Admin SDK writes compatible.
4.  **Import Cleanup:** Removed unused functions from `firebase/firestore` imports to keep route handlers tidy.

**Verification:**
*   Confirmed successful `npm run build` with no syntax or Turbopack errors.
*   Verified unit tests pass with `npx vitest run`.
*   Passed automated Code Review to ensure all `.get()` queries and nested parens match perfectly.

---
*PR created automatically by Jules for task [4774340013547859924](https://jules.google.com/task/4774340013547859924) started by @JClouddd*