### PR TITLE
⚡ Optimize Firestore Writes in Email Pipeline

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,28 @@
+import { POST } from './src/app/api/automation/email-pipeline/route.js';
+
+// Mock request
+const mockRequest = (body) => ({
+  json: async () => body,
+});
+
+async function run() {
+  const emails = [];
+  for (let i = 0; i < 50; i++) {
+    emails.push({
+      id: `email-${i}`,
+      from: `user${i}@example.com`,
+      subject: `Invoice ${i}`,
+      snippet: `Here is your invoice`,
+      category: 'client',
+      urgency: 'normal',
+    });
+  }
+
+  const start = Date.now();
+  const res = await POST(mockRequest({ emails }));
+  const data = await res.json();
+  const end = Date.now();
+  console.log(`Time taken: ${end - start}ms`, data);
+}
+
+run();

--- a/src/app/api/automation/email-pipeline/__tests__/route.test.js
+++ b/src/app/api/automation/email-pipeline/__tests__/route.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { POST } from '../route.js';
+
+vi.mock('@/lib/firebaseAdmin', () => ({
+  adminDb: {
+    batch: vi.fn().mockReturnValue({
+      set: vi.fn(),
+      commit: vi.fn().mockImplementation(() => new Promise(resolve => setTimeout(resolve, 5)))
+    }),
+    collection: vi.fn().mockReturnValue({
+      add: vi.fn().mockImplementation(() => new Promise(resolve => setTimeout(() => resolve({ id: 'mock-doc-id' }), 5))),
+      doc: vi.fn().mockReturnValue({ id: 'mock-doc-id' })
+    }),
+    doc: vi.fn().mockReturnValue({
+      get: vi.fn().mockResolvedValue({ exists: false })
+    })
+  }
+}));
+
+describe('email-pipeline POST', () => {
+  it('processes emails and measures time taken', async () => {
+    const emails = [];
+    for (let i = 0; i < 50; i++) {
+      emails.push({
+        id: `email-${i}`,
+        from: `user${i}@example.com`,
+        subject: `Test ${i}`,
+        snippet: `Snippet ${i}`,
+        category: 'client',
+        urgency: 'normal',
+      });
+    }
+
+    const mockRequest = {
+      json: vi.fn().mockResolvedValue({ emails })
+    };
+
+    const start = Date.now();
+    const res = await POST(mockRequest);
+    const data = await res.json();
+    const end = Date.now();
+
+    console.log(`Optimized time: ${end - start}ms`);
+    expect(res.status).toBe(200);
+    expect(data.clientsLinked).toBe(50);
+  });
+});

--- a/src/app/api/automation/email-pipeline/route.js
+++ b/src/app/api/automation/email-pipeline/route.js
@@ -16,6 +16,7 @@ export async function POST(request) {
     let invoicesLogged = 0;
 
     let accessToken = null;
+    const batch = adminDb.batch();
 
     for (const email of emails) {
       const { id, from, subject, snippet, category, urgency } = email;
@@ -63,7 +64,8 @@ export async function POST(request) {
       // 2. Client linkage
       if (category === "client") {
         try {
-          await adminDb.collection("client_emails").add( {
+          const docRef = adminDb.collection("client_emails").doc();
+          batch.set(docRef, {
             emailId: id,
             from,
             matchedClient: from, // simplified for now
@@ -79,7 +81,8 @@ export async function POST(request) {
       const lowerSubject = (subject || "").toLowerCase();
       if (category === "invoice" || lowerSubject.includes("invoice") || lowerSubject.includes("receipt")) {
         try {
-          await adminDb.collection("income_entries").add( {
+          const docRef = adminDb.collection("income_entries").doc();
+          batch.set(docRef, {
             from,
             subject,
             timestamp: new Date().toISOString(),
@@ -89,6 +92,14 @@ export async function POST(request) {
         } catch (err) {
           console.error("Failed to log invoice for email", id, err);
         }
+      }
+    }
+
+    if (clientsLinked > 0 || invoicesLogged > 0) {
+      try {
+        await batch.commit();
+      } catch (err) {
+        console.error("Failed to commit batch", err);
       }
     }
 


### PR DESCRIPTION
💡 **What:** Replaced sequential `adminDb.collection().add()` calls inside a loop with a single `adminDb.batch().commit()` at the end of the email processing loop for both the client linkages and invoice logs.
🎯 **Why:** To resolve an N+1 Firestore write issue where multiple network calls were made sequentially inside a loop, reducing API overhead and significantly improving performance.
📊 **Measured Improvement:** In a local Vitest benchmark mocking a 5ms delay per `add` vs a single 5ms `commit` across 50 records:
- Baseline (Sequential): ~293ms
- Improved (Batched): ~55ms
- The process is now ~5x faster.

---
*PR created automatically by Jules for task [3141522863816655815](https://jules.google.com/task/3141522863816655815) started by @JClouddd*