### PR TITLE
feat: Add Gmail label management to the Email Module

### DIFF
--- a/src/app/api/email/inbox/route.js
+++ b/src/app/api/email/inbox/route.js
@@ -1,4 +1,4 @@
-import { getGmailInbox, refreshAccessToken, googleApiRequest } from "@/lib/googleAuth";
+import { getGmailInbox, refreshAccessToken, googleApiRequest, listGmailLabels, createGmailLabel, applyGmailLabel } from "@/lib/googleAuth";
 import { adminDb } from "@/lib/firebaseAdmin";
 
 /**
@@ -79,6 +79,51 @@ export async function GET(request) {
               }
               return msg;
             });
+
+
+            // Auto-apply labels
+            try {
+              let currentLabels = [];
+              try {
+                const labelsRes = await listGmailLabels(accessToken);
+                currentLabels = labelsRes.labels || [];
+              } catch (e) {
+                console.error("Failed to list labels:", e);
+              }
+
+              const categoryToLabel = {}; // Cache label mapping
+
+              for (const msg of classifiedMessages) {
+                if (msg.category && msg.category !== "unknown") {
+                  // Map category e.g., "client" -> "Gravix/Client"
+                  const categoryName = msg.category.charAt(0).toUpperCase() + msg.category.slice(1);
+                  const labelName = `Gravix/${categoryName}`;
+
+                  let labelId = categoryToLabel[labelName];
+
+                  if (!labelId) {
+                    const existingLabel = currentLabels.find(l => l.name === labelName);
+                    if (existingLabel) {
+                      labelId = existingLabel.id;
+                    } else {
+                      // Create label
+                      const newLabel = await createGmailLabel(accessToken, labelName, "#4285f4", "#ffffff");
+                      labelId = newLabel.id;
+                      currentLabels.push(newLabel);
+                    }
+                    categoryToLabel[labelName] = labelId;
+                  }
+
+                  if (labelId) {
+                    await applyGmailLabel(accessToken, msg.id, [labelId], []);
+                    // Update the message in our result array
+                    msg.labelIds = [...(msg.labelIds || []), labelId];
+                  }
+                }
+              }
+            } catch (lblErr) {
+              console.error("Failed to auto-apply labels:", lblErr);
+            }
 
             // Trigger pipeline only on first load
             await fetch(`${origin}/api/automation/email-pipeline`, {

--- a/src/app/api/email/labels/apply/route.js
+++ b/src/app/api/email/labels/apply/route.js
@@ -1,0 +1,41 @@
+import { applyGmailLabel, refreshAccessToken } from "@/lib/googleAuth";
+import { adminDb } from "@/lib/firebaseAdmin";
+
+async function getAccessToken() {
+  const tokensDoc = await adminDb.collection("settings").doc("google_oauth").get();
+  if (!tokensDoc.exists) {
+    throw new Error("Gmail is not connected.");
+  }
+
+  const tokens = tokensDoc.data();
+  let accessToken = tokens.accessToken;
+
+  if (Date.now() > tokens.expiresAt) {
+    const refreshed = await refreshAccessToken(tokens.refreshToken);
+    accessToken = refreshed.access_token;
+    await adminDb.collection("settings").doc("google_oauth").update({
+      accessToken: refreshed.access_token,
+      expiresAt: Date.now() + (refreshed.expires_in * 1000),
+    });
+  }
+
+  return accessToken;
+}
+
+export async function POST(request) {
+  try {
+    const { messageId, addLabelIds, removeLabelIds } = await request.json();
+
+    if (!messageId) {
+      return Response.json({ error: "messageId is required" }, { status: 400 });
+    }
+
+    const accessToken = await getAccessToken();
+    await applyGmailLabel(accessToken, messageId, addLabelIds || [], removeLabelIds || []);
+
+    return Response.json({ success: true });
+  } catch (error) {
+    console.error("[/api/email/labels/apply POST]", error);
+    return Response.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/src/app/api/email/labels/route.js
+++ b/src/app/api/email/labels/route.js
@@ -1,0 +1,56 @@
+import { listGmailLabels, createGmailLabel, refreshAccessToken } from "@/lib/googleAuth";
+import { adminDb } from "@/lib/firebaseAdmin";
+
+async function getAccessToken() {
+  const tokensDoc = await adminDb.collection("settings").doc("google_oauth").get();
+  if (!tokensDoc.exists) {
+    throw new Error("Gmail is not connected.");
+  }
+
+  const tokens = tokensDoc.data();
+  let accessToken = tokens.accessToken;
+
+  if (Date.now() > tokens.expiresAt) {
+    const refreshed = await refreshAccessToken(tokens.refreshToken);
+    accessToken = refreshed.access_token;
+    await adminDb.collection("settings").doc("google_oauth").update({
+      accessToken: refreshed.access_token,
+      expiresAt: Date.now() + (refreshed.expires_in * 1000),
+    });
+  }
+
+  return accessToken;
+}
+
+export async function GET(request) {
+  try {
+    const accessToken = await getAccessToken();
+    const result = await listGmailLabels(accessToken);
+
+    // Filter to only return user labels
+    const userLabels = (result.labels || []).filter(label => label.type === "user");
+
+    return Response.json({ labels: userLabels });
+  } catch (error) {
+    console.error("[/api/email/labels GET]", error);
+    return Response.json({ error: error.message }, { status: 500 });
+  }
+}
+
+export async function POST(request) {
+  try {
+    const { name, backgroundColor, textColor } = await request.json();
+
+    if (!name) {
+      return Response.json({ error: "Name is required" }, { status: 400 });
+    }
+
+    const accessToken = await getAccessToken();
+    const result = await createGmailLabel(accessToken, name, backgroundColor, textColor);
+
+    return Response.json({ success: true, label: result });
+  } catch (error) {
+    console.error("[/api/email/labels POST]", error);
+    return Response.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/src/components/modules/EmailModule.js
+++ b/src/components/modules/EmailModule.js
@@ -11,6 +11,11 @@ import HelpTooltip from "@/components/HelpTooltip";
 export default function EmailModule() {
   const [isConnected, setIsConnected] = useState(true);
   const [isLoading, setIsLoading] = useState(true);
+  const [labels, setLabels] = useState([]);
+  const [selectedLabelId, setSelectedLabelId] = useState("all");
+  const [showNewLabelForm, setShowNewLabelForm] = useState(false);
+  const [newLabelName, setNewLabelName] = useState("");
+  const [isCreatingLabel, setIsCreatingLabel] = useState(false);
   const [error, setError] = useState(null);
   const [inbox, setInbox] = useState([]);
   const [stats, setStats] = useState({ total: 0, unread: 0 });
@@ -64,6 +69,55 @@ export default function EmailModule() {
       setIsLoadingTemplates(false);
     }
   };
+
+
+  const fetchLabels = async () => {
+    try {
+      const res = await fetch("/api/email/labels");
+      if (res.ok) {
+        const data = await res.json();
+        setLabels(data.labels || []);
+      }
+    } catch (err) {
+      console.error("Failed to fetch labels:", err);
+    }
+  };
+
+  const handleCreateLabel = async () => {
+    if (!newLabelName) return;
+    setIsCreatingLabel(true);
+    try {
+      const res = await fetch("/api/email/labels", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: newLabelName,
+          backgroundColor: "#4285f4",
+          textColor: "#ffffff"
+        })
+      });
+      if (res.ok) {
+        const data = await res.json();
+        if (data.label) {
+          setLabels(prev => [...prev, data.label]);
+        }
+        setShowNewLabelForm(false);
+        setNewLabelName("");
+      } else {
+        alert("Failed to create label");
+      }
+    } catch (err) {
+      console.error("Failed to create label:", err);
+    } finally {
+      setIsCreatingLabel(false);
+    }
+  };
+
+  useEffect(() => {
+    Promise.resolve().then(() => {
+      fetchLabels();
+    });
+  }, []);
 
   const fetchInbox = async () => {
     setIsLoading(true);
@@ -388,6 +442,11 @@ export default function EmailModule() {
     );
   }
 
+
+  const filteredInbox = selectedLabelId === "all"
+    ? inbox
+    : inbox.filter(email => email.labelIds && email.labelIds.includes(selectedLabelId));
+
   return (
     <div>
       <div className="module-header">
@@ -432,6 +491,79 @@ export default function EmailModule() {
               </div>
             )}
 
+            {/* Label Chips Bar */}
+            <div style={{ display: "flex", gap: "8px", overflowX: "auto", padding: "12px 24px", borderBottom: "1px solid var(--card-border)", alignItems: "center" }}>
+              <button
+                onClick={() => setSelectedLabelId("all")}
+                style={{
+                  padding: "4px 12px",
+                  borderRadius: "16px",
+                  fontSize: "12px",
+                  cursor: "pointer",
+                  whiteSpace: "nowrap",
+                  border: "1px solid var(--text-tertiary)",
+                  background: selectedLabelId === "all" ? "var(--text-primary)" : "transparent",
+                  color: selectedLabelId === "all" ? "var(--bg-primary)" : "var(--text-primary)",
+                  transition: "all 0.2s"
+                }}
+              >
+                All
+              </button>
+              {labels.map(label => (
+                <button
+                  key={label.id}
+                  onClick={() => setSelectedLabelId(label.id)}
+                  style={{
+                    padding: "4px 12px",
+                    borderRadius: "16px",
+                    fontSize: "12px",
+                    cursor: "pointer",
+                    whiteSpace: "nowrap",
+                    border: `1px solid ${label.color?.backgroundColor || "var(--accent)"}`,
+                    background: selectedLabelId === label.id ? (label.color?.backgroundColor || "var(--accent)") : "transparent",
+                    color: selectedLabelId === label.id ? (label.color?.textColor || "#fff") : (label.color?.backgroundColor || "var(--accent)"),
+                    transition: "all 0.2s"
+                  }}
+                >
+                  {label.name.replace("Gravix/", "")}
+                </button>
+              ))}
+              <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+                {!showNewLabelForm ? (
+                  <button
+                    onClick={() => setShowNewLabelForm(true)}
+                    style={{
+                      padding: "4px 12px",
+                      borderRadius: "16px",
+                      fontSize: "12px",
+                      cursor: "pointer",
+                      whiteSpace: "nowrap",
+                      border: "1px dashed var(--text-tertiary)",
+                      background: "transparent",
+                      color: "var(--text-secondary)",
+                      transition: "all 0.2s"
+                    }}
+                  >
+                    + New Label
+                  </button>
+                ) : (
+                  <div style={{ display: "flex", gap: "4px", alignItems: "center" }}>
+                    <input
+                      autoFocus
+                      type="text"
+                      value={newLabelName}
+                      onChange={e => setNewLabelName(e.target.value)}
+                      placeholder="Label name"
+                      style={{ padding: "2px 8px", fontSize: "12px", borderRadius: "12px", border: "1px solid var(--card-border)", outline: "none", width: "100px" }}
+                    />
+                    <button onClick={handleCreateLabel} disabled={isCreatingLabel} style={{ background: "var(--success)", color: "#fff", border: "none", borderRadius: "12px", padding: "2px 8px", fontSize: "12px", cursor: "pointer" }}>✓</button>
+                    <button onClick={() => setShowNewLabelForm(false)} style={{ background: "var(--error)", color: "#fff", border: "none", borderRadius: "12px", padding: "2px 8px", fontSize: "12px", cursor: "pointer" }}>✕</button>
+                  </div>
+                )}
+              </div>
+            </div>
+
+
             {isLoading ? (
               Array(5).fill(0).map((_, idx) => (
                 <div key={idx} style={{ display: "flex", padding: "16px 24px", borderBottom: "1px solid var(--card-border)" }}>
@@ -444,12 +576,12 @@ export default function EmailModule() {
                 </div>
               ))
             ) : (
-              inbox.length === 0 && !error ? (
+              filteredInbox.length === 0 && !error ? (
                 <div style={{ padding: "32px 24px", textAlign: "center", color: "var(--text-secondary)" }}>
                   No emails found.
                 </div>
               ) : (
-                inbox.map((email, idx) => {
+                filteredInbox.map((email, idx) => {
                   const isUnread = !email.isRead;
                   const senderName = email.from ? email.from.split("<")[0].trim().replace(/"/g, "") : "Unknown";
                   const avatarLetter = senderName ? senderName.charAt(0).toUpperCase() : "?";
@@ -467,7 +599,7 @@ export default function EmailModule() {
                       style={{
                         display: "flex",
                         padding: "16px 24px",
-                        borderBottom: idx < inbox.length - 1 ? "1px solid var(--card-border)" : "none",
+                        borderBottom: idx < filteredInbox.length - 1 ? "1px solid var(--card-border)" : "none",
                         cursor: "pointer",
                         background: isUnread ? "var(--bg-hover)" : "transparent",
                         borderLeft: isUnread ? "4px solid var(--accent)" : "4px solid transparent",
@@ -491,11 +623,26 @@ export default function EmailModule() {
                         </div>
                         <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
                           <span style={{ fontWeight: isUnread ? 600 : 500, color: "var(--text-primary)", fontSize: 14 }}>{email.subject}</span>
+
                           {classification && (
                              <span className={`badge ${badgeClass}`}>
                                 {classification.category}
                              </span>
                           )}
+                          {email.labelIds && labels.filter(l => email.labelIds.includes(l.id)).map(label => (
+                             <span
+                               key={label.id}
+                               className="badge"
+                               style={{
+                                 backgroundColor: label.color?.backgroundColor || "var(--accent)",
+                                 color: label.color?.textColor || "#fff",
+                                 border: "none"
+                               }}
+                             >
+                               {label.name.replace("Gravix/", "")}
+                             </span>
+                          ))}
+
                           {isUnread && (
                             <span className="badge badge-info">
                               Unread


### PR DESCRIPTION
Adds the ability to manage and filter Gmail labels within the Gravix Email Module. Automatically applies "Gravix/[Category]" labels to newly fetched emails post-classification, and introduces a UI to create new user labels and filter the inbox view accordingly.

---
*PR created automatically by Jules for task [9791281010799233669](https://jules.google.com/task/9791281010799233669) started by @JClouddd*