### PR TITLE
Add Knowledge Graph Tab and Linked Notebooks

### DIFF
--- a/src/app/api/agents/roster/route.js
+++ b/src/app/api/agents/roster/route.js
@@ -65,7 +65,10 @@ const AGENT_REGISTRY = Object.entries(registry.agents).map(([id, data]) => ({
   role: data.role,
   status: "active",
   dialogflowCxId: data.id,
-  skills: data.skills || [],
+  skills: (data.skills || []).map(skill => ({
+    ...skill,
+    linkedNotebooks: []
+  })),
   subAgents: data.subAgents || [],
   ...AGENT_EXTRAS[id],
 }));

--- a/src/app/api/knowledge/context/__tests__/route.test.js
+++ b/src/app/api/knowledge/context/__tests__/route.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { GET } from '../route';
+
+describe('Knowledge Context API', () => {
+  it('returns empty notebooks for domains=all', async () => {
+    const req = {
+      url: 'http://localhost/api/knowledge/context?domains=all'
+    };
+    const response = await GET(req);
+    const data = await response.json();
+    expect(data.notebooks).toEqual([]);
+  });
+
+  it('returns empty notebooks for other requests', async () => {
+    const req = {
+      url: 'http://localhost/api/knowledge/context'
+    };
+    const response = await GET(req);
+    const data = await response.json();
+    expect(data.notebooks).toEqual([]);
+  });
+});

--- a/src/app/api/knowledge/context/route.js
+++ b/src/app/api/knowledge/context/route.js
@@ -1,0 +1,13 @@
+export async function GET(request) {
+  const { searchParams } = new URL(request.url);
+  const domains = searchParams.get('domains');
+
+  if (domains === 'all') {
+    // For now, return an empty array of notebooks to trigger the placeholder.
+    return Response.json({
+      notebooks: []
+    });
+  }
+
+  return Response.json({ notebooks: [] });
+}

--- a/src/components/modules/AgentsModule.js
+++ b/src/components/modules/AgentsModule.js
@@ -8,6 +8,9 @@ const TABS = ["Roster", "Skills", "Workflow", "Tasks", "Proposals", "History"];
 export default function AgentsModule() {
   const [activeTab, setActiveTab] = useState("Roster");
 
+  // Skills state
+  const [expandedSkillId, setExpandedSkillId] = useState(null);
+
   // Roster state
   const [agents, setAgents] = useState([]);
   const [isLoadingAgents, setIsLoadingAgents] = useState(true);
@@ -600,7 +603,33 @@ export default function AgentsModule() {
                   }}>
                     {skill.category}
                   </span>
+                  <button className="badge" style={{
+                    fontSize: 10,
+                    background: "var(--bg-secondary)",
+                    color: "var(--text-secondary)",
+                    border: "1px solid var(--card-border)",
+                    cursor: "pointer"
+                  }} onClick={(e) => {
+                    e.stopPropagation();
+                    setExpandedSkillId(expandedSkillId === skill.id ? null : skill.id);
+                  }}>
+                    {skill.linkedNotebooks?.length || 0} Linked Notebooks
+                  </button>
                 </div>
+                {expandedSkillId === skill.id && (
+                  <div style={{ marginTop: 12, paddingTop: 12, borderTop: "1px solid var(--card-border)" }}>
+                    <div style={{ fontSize: 11, fontWeight: 600, color: "var(--text-primary)", marginBottom: 8 }}>Linked Notebooks</div>
+                    {skill.linkedNotebooks && skill.linkedNotebooks.length > 0 ? (
+                      <ul style={{ listStyleType: "disc", paddingLeft: 16, margin: 0, color: "var(--text-secondary)", fontSize: 11 }}>
+                        {skill.linkedNotebooks.map((nb, i) => <li key={i}>{nb}</li>)}
+                      </ul>
+                    ) : (
+                      <div style={{ fontSize: 11, color: "var(--text-secondary)", fontStyle: "italic" }}>
+                        0 notebooks
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
             ))}
           </div>

--- a/src/components/modules/KnowledgeModule.js
+++ b/src/components/modules/KnowledgeModule.js
@@ -6,12 +6,13 @@ import KnowledgeVaultTab from "./knowledge/KnowledgeVaultTab";
 import IngestionTab from "./knowledge/IngestionTab";
 import ScholarChatTab from "./knowledge/ScholarChatTab";
 import SourcesTab from "./knowledge/SourcesTab";
+import GraphTab from "./knowledge/GraphTab";
 
 /**
  * Knowledge Module — Brain Vault + Ingestion staging + Scholar chat
  * Fully wired to /api/knowledge/* endpoints
  */
-const TABS = ["Knowledge", "Ingestion", "Scholar", "Sources"];
+const TABS = ["Knowledge", "Graph", "Ingestion", "Scholar", "Sources"];
 
 export default function KnowledgeModule() {
   const [activeTab, setActiveTab] = useState("Knowledge");
@@ -93,6 +94,10 @@ export default function KnowledgeModule() {
       {/* Tab Content */}
       <div style={{ display: activeTab === "Knowledge" ? "block" : "none" }}>
         <KnowledgeVaultTab status={status} setActiveTab={setActiveTab} />
+      </div>
+
+      <div style={{ display: activeTab === "Graph" ? "block" : "none" }}>
+        <GraphTab />
       </div>
 
       <div style={{ display: activeTab === "Ingestion" ? "block" : "none" }}>

--- a/src/components/modules/knowledge/GraphTab.js
+++ b/src/components/modules/knowledge/GraphTab.js
@@ -1,0 +1,114 @@
+import { useState, useEffect } from "react";
+
+export default function GraphTab() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/knowledge/context?domains=all")
+      .then((r) => r.json())
+      .then((d) => {
+        setData(d);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return <div className="skeleton skeleton-card" style={{ height: 300 }} />;
+  }
+
+  if (!data?.notebooks || data.notebooks.length === 0) {
+    return (
+      <div className="card">
+        <div className="empty-state">
+          <div className="empty-state-icon">🕸️</div>
+          <p className="empty-state-title">Knowledge Graph</p>
+          <p className="empty-state-desc">
+            Approve notebooks to see knowledge connections
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Group nodes by domain/category
+  // Notebooks
+  const notebooksByCategory = (data.notebooks || []).reduce((acc, nb) => {
+    const cat = nb.category || "uncategorized";
+    if (!acc[cat]) acc[cat] = [];
+    acc[cat].push(nb);
+    return acc;
+  }, {});
+
+  // Agent Skills (passed from data if available, assuming empty for now)
+  const skillsByCategory = (data.skills || []).reduce((acc, skill) => {
+    const cat = skill.category || "uncategorized";
+    if (!acc[cat]) acc[cat] = [];
+    acc[cat].push(skill);
+    return acc;
+  }, {});
+
+  const allCategories = Array.from(new Set([
+    ...Object.keys(notebooksByCategory),
+    ...Object.keys(skillsByCategory)
+  ]));
+
+  const getDomainColor = (index) => {
+    const colors = ["var(--accent)", "var(--success)", "var(--warning)", "var(--agent-scholar)", "var(--agent-analyst)"];
+    return colors[index % colors.length];
+  };
+
+  return (
+    <div className="card">
+      <h3 className="h3" style={{ marginBottom: 16 }}>Knowledge Graph</h3>
+      <p className="body-sm" style={{ marginBottom: 24, color: "var(--text-secondary)" }}>
+        Visualizing connections between ingested notebooks and agent skills.
+      </p>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 32 }}>
+        {allCategories.map((cat, i) => {
+          const color = getDomainColor(i);
+          const nbs = notebooksByCategory[cat] || [];
+          const skills = skillsByCategory[cat] || [];
+
+          return (
+            <div key={cat} style={{
+              background: `color-mix(in srgb, ${color} 10%, transparent)`,
+              border: `1px solid color-mix(in srgb, ${color} 30%, transparent)`,
+              borderRadius: "var(--radius-lg)",
+              padding: 24,
+            }}>
+              <h4 className="h4" style={{ marginBottom: 16, textTransform: "capitalize", color }}>
+                {cat} Domain
+              </h4>
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))", gap: 16 }}>
+
+                {nbs.map((nb, j) => (
+                  <div key={`nb-${j}`} className="card card-glass" style={{ borderLeft: `3px solid ${color}` }}>
+                     <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+                       <span style={{ fontSize: 16 }}>📓</span>
+                       <p className="body-sm" style={{ fontWeight: 600 }}>{nb.name}</p>
+                     </div>
+                     <span className="badge" style={{ background: "var(--bg-secondary)" }}>{nb.type || "Notebook"}</span>
+                  </div>
+                ))}
+
+                {skills.map((skill, k) => (
+                  <div key={`skill-${k}`} className="card card-glass" style={{ borderLeft: `3px dashed ${color}` }}>
+                     <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+                       <span style={{ fontSize: 16 }}>⚙️</span>
+                       <p className="body-sm" style={{ fontWeight: 600 }}>{skill.name}</p>
+                     </div>
+                     <span className="badge" style={{ background: "var(--bg-secondary)" }}>Owner: {skill.agentOwner || "Unknown"}</span>
+                  </div>
+                ))}
+
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a "Knowledge Graph" tab to `KnowledgeModule` that maps notebooks to domains/categories, updates `AgentsModule` to display linked notebooks under skills, and implements a mock `/api/knowledge/context` API.

---
*PR created automatically by Jules for task [41280466614176512](https://jules.google.com/task/41280466614176512) started by @JClouddd*