### PR TITLE
feat: add sentinel diagnostic system api routes

### DIFF
--- a/src/app/api/jules/monitor/route.js
+++ b/src/app/api/jules/monitor/route.js
@@ -246,6 +246,7 @@ export async function GET() {
                 });
                 await logToFirestore(id, title, "failed_exhausted", "Max retries reached");
               }
+            }
             break;
           }
 

--- a/src/app/api/sentinel/diagnose/route.js
+++ b/src/app/api/sentinel/diagnose/route.js
@@ -1,0 +1,60 @@
+import { generate } from "@/lib/geminiClient";
+import { logRouteError } from "@/lib/errorLogger";
+
+export async function POST(request) {
+  try {
+    const { errorData } = await request.json();
+
+    if (!errorData) {
+      return Response.json(
+        { error: "Missing errorData in request body" },
+        { status: 400 }
+      );
+    }
+
+    const { message, source, route, stackTrace } = errorData;
+
+    const prompt = `Analyze the following system error:
+Source: ${source || "unknown"}
+Route: ${route || "unknown"}
+Message: ${message || "unknown"}
+Stack Trace: ${stackTrace || "none"}`;
+
+    const systemPrompt = `You are an expert root-cause analysis diagnostic agent.
+Analyze the provided system error and return a structured JSON response diagnosing the issue.`;
+
+    const jsonSchema = {
+      type: "object",
+      properties: {
+        diagnosis: { type: "string" },
+        severity: { type: "string" },
+        julesCanFix: { type: "boolean" },
+        fixPrompt: { type: "string", nullable: true },
+        fileLocks: { type: "array", items: { type: "string" } },
+      },
+      required: ["diagnosis", "severity", "julesCanFix", "fileLocks"],
+    };
+
+    const diagnosisResult = await generate({
+      prompt,
+      systemPrompt,
+      complexity: "quick",
+      jsonSchema,
+    });
+
+    let structuredData;
+    try {
+      structuredData = JSON.parse(diagnosisResult.text);
+    } catch (parseError) {
+      throw new Error(`Failed to parse Gemini response as JSON: ${diagnosisResult.text}`);
+    }
+
+    return Response.json(structuredData);
+  } catch (error) {
+    logRouteError("runtime", "Sentinel Diagnose: Failed to process diagnostic", error, "/api/sentinel/diagnose");
+    return Response.json(
+      { error: "Internal Server Error", message: error.message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/sentinel/patrol/route.js
+++ b/src/app/api/sentinel/patrol/route.js
@@ -1,0 +1,147 @@
+import { adminDb } from "@/lib/firebaseAdmin";
+import { logRouteError } from "@/lib/errorLogger";
+
+export async function GET(request) {
+  try {
+    const origin = new URL(request.url).origin;
+    const checks = [];
+    const errorsList = [];
+    const staleLocksList = [];
+    let status = "healthy";
+
+    const now = new Date();
+    const timestamp = now.toISOString();
+
+    // 1. Check Firestore connectivity
+    try {
+      const start = Date.now();
+      await adminDb.collection("system_config").limit(1).get();
+      checks.push({
+        name: "firestore",
+        status: "pass",
+        latency: Date.now() - start,
+      });
+    } catch (error) {
+      logRouteError("firestore", "Sentinel Patrol: Firestore check failed", error, "/api/sentinel/patrol");
+      checks.push({
+        name: "firestore",
+        status: "fail",
+        error: error.message,
+      });
+      status = "critical";
+    }
+
+    // 2. Check all API route groups are responding
+    try {
+      const start = Date.now();
+      const healthRes = await fetch(`${origin}/api/health`, { redirect: 'error' });
+      const healthData = await healthRes.json();
+      if (!healthRes.ok) {
+        throw new Error(`Health API returned status ${healthRes.status}`);
+      }
+      checks.push({
+        name: "api_health",
+        status: "pass",
+        latency: Date.now() - start,
+        details: healthData.status,
+      });
+      if (healthData.status === "down") {
+        status = "critical";
+      } else if (healthData.status === "degraded" && status !== "critical") {
+        status = "degraded";
+      }
+    } catch (error) {
+      logRouteError("runtime", "Sentinel Patrol: API Health check failed", error, "/api/sentinel/patrol");
+      checks.push({
+        name: "api_health",
+        status: "fail",
+        error: error.message,
+      });
+      status = "critical";
+    }
+
+    // 3. Check for recent errors in system_errors collection
+    try {
+      const start = Date.now();
+      const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000).toISOString();
+      const errorSnap = await adminDb
+        .collection("system_errors")
+        .where("createdAt", ">=", oneHourAgo)
+        .get();
+
+      errorSnap.forEach((doc) => {
+        errorsList.push({ id: doc.id, ...doc.data() });
+      });
+
+      checks.push({
+        name: "system_errors",
+        status: "pass",
+        latency: Date.now() - start,
+        count: errorsList.length,
+      });
+
+      if (errorsList.length > 0 && status !== "critical") {
+        status = "degraded";
+      }
+    } catch (error) {
+      logRouteError("firestore", "Sentinel Patrol: System errors check failed", error, "/api/sentinel/patrol");
+      checks.push({
+        name: "system_errors",
+        status: "fail",
+        error: error.message,
+      });
+      if (status !== "critical") status = "degraded";
+    }
+
+    // 4. Check jules_file_locks for stale locks
+    try {
+      const start = Date.now();
+      const twentyFourHoursAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+      const locksSnap = await adminDb
+        .collection("jules_file_locks")
+        .where("createdAt", "<=", twentyFourHoursAgo)
+        .get();
+
+      locksSnap.forEach((doc) => {
+        staleLocksList.push({ id: doc.id, ...doc.data() });
+      });
+
+      checks.push({
+        name: "stale_locks",
+        status: "pass",
+        latency: Date.now() - start,
+        count: staleLocksList.length,
+      });
+
+      if (staleLocksList.length > 0 && status !== "critical") {
+        status = "degraded";
+      }
+    } catch (error) {
+      logRouteError("firestore", "Sentinel Patrol: Stale locks check failed", error, "/api/sentinel/patrol");
+      checks.push({
+        name: "stale_locks",
+        status: "fail",
+        error: error.message,
+      });
+      if (status !== "critical") status = "degraded";
+    }
+
+    return Response.json({
+      status,
+      checks,
+      errors: errorsList,
+      stale_locks: staleLocksList,
+      timestamp,
+    });
+  } catch (error) {
+    logRouteError("runtime", "Sentinel Patrol: Unhandled exception", error, "/api/sentinel/patrol");
+    return Response.json(
+      {
+        status: "critical",
+        error: error.message,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
This PR introduces two new API endpoints for the Sentinel diagnostic system to monitor system health and perform AI-powered root-cause analysis on errors.

### Implementation Details
* **GET `/api/sentinel/patrol`**: Performs a full health sweep:
  - Validates Firestore connectivity (`system_config`).
  - Pings the `/api/health` route dynamically based on request origin to verify all API route groups are responding.
  - Queries the `system_errors` collection for new errors in the last hour.
  - Queries `jules_file_locks` for stale locks older than 24 hours.
  - Returns a structured report summarizing status (`healthy`, `degraded`, or `critical`).
* **POST `/api/sentinel/diagnose`**: Performs root-cause analysis:
  - Accepts a payload containing `errorData` (message, source, route, stack trace).
  - Uses the `generate` function from `@/lib/geminiClient.js` configured with the `quick` complexity tier and a strict `jsonSchema` constraint.
  - Returns structured AI-diagnosed payload detailing severity, root-cause, file locks, and fix prompts.

All endpoints adhere to conventions, strictly use `logRouteError` for catching runtime/fetch exceptions, and use `adminDb` via server-side context.

---
*PR created automatically by Jules for task [14034060696842163382](https://jules.google.com/task/14034060696842163382) started by @JClouddd*