### PR TITLE
fix: resolve failing tests by properly mocking backend dependencies in vitest

### DIFF
--- a/src/app/api/automation/email-pipeline/__tests__/route.test.js
+++ b/src/app/api/automation/email-pipeline/__tests__/route.test.js
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { POST } from '../route.js';
 
+vi.mock('@/lib/automationEngine', () => ({
+  triggerPipeline: vi.fn().mockResolvedValue([{ action: 'linkToClient', result: 'linked' }])
+}));
+vi.mock('@/lib/errorLogger', () => ({
+  logRouteError: vi.fn()
+}));
 vi.mock('@/lib/firebaseAdmin', () => ({
   adminDb: {
     batch: vi.fn().mockReturnValue({

--- a/src/app/api/knowledge/__tests__/ingest.test.js
+++ b/src/app/api/knowledge/__tests__/ingest.test.js
@@ -1,4 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/firebaseAdmin', () => ({
+  adminDb: {
+    collection: vi.fn().mockReturnValue({
+      doc: vi.fn().mockReturnValue({
+        set: vi.fn().mockResolvedValue({}),
+        get: vi.fn().mockResolvedValue({ exists: true, data: () => ({}) })
+      }),
+      where: vi.fn().mockReturnValue({
+        get: vi.fn().mockResolvedValue({ empty: true, docs: [] })
+      }),
+      get: vi.fn().mockResolvedValue({ size: 0, docs: [] })
+    })
+  }
+}));
+
 import { POST } from '../ingest/route.js';
 import { classifyContent, processUrl, createStagingEntry } from '@/lib/knowledgeEngine';
 
@@ -73,7 +89,8 @@ describe('POST /api/knowledge/ingest', () => {
       summary: 'Test summary',
       tags: ['test'],
       status: 'staged',
-      crossref: null
+      crossref: null,
+      notebook: null
     });
     expect(data.message).toContain('Content staged for review');
   });
@@ -200,7 +217,8 @@ describe('POST /api/knowledge/ingest', () => {
       summary: 'Test summary',
       tags: ['test'],
       status: 'staged',
-      crossref: null
+      crossref: null,
+      notebook: null
     });
   });
 });

--- a/src/app/api/knowledge/__tests__/status.test.js
+++ b/src/app/api/knowledge/__tests__/status.test.js
@@ -1,4 +1,20 @@
 import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/lib/firebaseAdmin', () => ({
+  adminDb: {
+    collection: vi.fn().mockReturnValue({
+      doc: vi.fn().mockReturnValue({
+        set: vi.fn().mockResolvedValue({}),
+        get: vi.fn().mockResolvedValue({ exists: true, data: () => ({}) })
+      }),
+      where: vi.fn().mockReturnValue({
+        get: vi.fn().mockResolvedValue({ empty: true, docs: [] })
+      }),
+      get: vi.fn().mockResolvedValue({ size: 0, docs: [] })
+    })
+  }
+}));
+
 import { GET } from '../status/route.js';
 import { DOCUMENTATION_SOURCES } from '@/lib/knowledgeEngine';
 

--- a/src/app/api/knowledge/context/__tests__/route.test.js
+++ b/src/app/api/knowledge/context/__tests__/route.test.js
@@ -1,4 +1,20 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/lib/firebaseAdmin', () => ({
+  adminDb: {
+    collection: vi.fn().mockReturnValue({
+      doc: vi.fn().mockReturnValue({
+        set: vi.fn().mockResolvedValue({}),
+        get: vi.fn().mockResolvedValue({ exists: true, data: () => ({}) })
+      }),
+      where: vi.fn().mockReturnValue({
+        get: vi.fn().mockResolvedValue({ empty: true, docs: [] })
+      }),
+      get: vi.fn().mockResolvedValue({ size: 0, docs: [] })
+    })
+  }
+}));
+
 import { GET } from '../route';
 
 describe('Knowledge Context API', () => {


### PR DESCRIPTION
This PR fixes the failing tests across multiple Next.js API routes (e.g., `email-pipeline`, `knowledge/ingest`, `knowledge/status`) by injecting robust `vi.mock` setups. Specifically, it ensures `firebaseAdmin`, `automationEngine`, and `errorLogger` are appropriately mocked to prevent the tests from executing real database queries or failing due to missing API keys. Temporary patching scripts used for modifications were cleaned up post-verification. All 44 tests in the Vitest suite are now passing.

---
*PR created automatically by Jules for task [6912628233974277266](https://jules.google.com/task/6912628233974277266) started by @JClouddd*