### PR TITLE
feat: implement telegram webhook integration with AI chat history

### DIFF
--- a/__tests__/api/telegram/webhook.test.js
+++ b/__tests__/api/telegram/webhook.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '@/app/api/telegram/webhook/route';
+import { getHistory, appendHistory } from '@/lib/firestoreChatHistory';
+import geminiClient from '@/lib/geminiClient';
+import { logRouteError } from '@/lib/errorLogger';
+
+// Mock dependencies
+vi.mock('@/lib/firestoreChatHistory', () => ({
+  getHistory: vi.fn(),
+  appendHistory: vi.fn(),
+}));
+
+vi.mock('@/lib/geminiClient', () => ({
+  default: {
+    generate: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/errorLogger', () => ({
+  logRouteError: vi.fn(),
+}));
+
+// Mock fetch
+global.fetch = vi.fn();
+
+describe('Telegram Webhook Route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.TELEGRAM_CHAT_ID = '123456789';
+    process.env.TELEGRAM_ASSISTANT_BOT_TOKEN = 'test-bot-token';
+  });
+
+  const createRequest = (body) => {
+    return {
+      json: async () => body,
+    };
+  };
+
+  it('should return 200 OK without processing if message is missing', async () => {
+    const req = createRequest({ update_id: 123 });
+    const response = await POST(req);
+    const data = await response.json();
+
+    expect(data.success).toBe(true);
+    expect(getHistory).not.toHaveBeenCalled();
+    expect(geminiClient.generate).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('should return 200 OK without processing if chat_id does not match', async () => {
+    const req = createRequest({
+      message: {
+        chat: { id: '999999999' },
+        text: 'Hello',
+      },
+    });
+
+    const response = await POST(req);
+    const data = await response.json();
+
+    expect(data.success).toBe(true);
+    expect(getHistory).not.toHaveBeenCalled();
+    expect(geminiClient.generate).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('should process the message, call Gemini, and send a response back', async () => {
+    const req = createRequest({
+      message: {
+        chat: { id: '123456789' },
+        text: 'Hello bot',
+      },
+    });
+
+    const mockHistory = [{ role: 'user', content: 'Hi' }];
+    getHistory.mockResolvedValue(mockHistory);
+
+    geminiClient.generate.mockResolvedValue({
+      text: 'Hello human',
+    });
+
+    fetch.mockResolvedValue({
+      ok: true,
+    });
+
+    const response = await POST(req);
+    const data = await response.json();
+
+    expect(data.success).toBe(true);
+
+    expect(getHistory).toHaveBeenCalledWith('123456789');
+
+    expect(appendHistory).toHaveBeenCalledWith('123456789', 'user', 'Hello bot');
+
+    expect(geminiClient.generate).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: 'Hello bot',
+      history: mockHistory,
+    }));
+
+    expect(appendHistory).toHaveBeenCalledWith('123456789', 'model', 'Hello human');
+
+    expect(fetch).toHaveBeenCalledWith('https://api.telegram.org/bottest-bot-token/sendMessage', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({
+        chat_id: '123456789',
+        text: 'Hello human',
+      })
+    }));
+  });
+
+  it('should catch errors and return 200 OK after logging', async () => {
+    const req = createRequest({
+      message: {
+        chat: { id: '123456789' },
+        text: 'Error test',
+      },
+    });
+
+    const error = new Error('Test error');
+    getHistory.mockRejectedValue(error);
+
+    const response = await POST(req);
+    const data = await response.json();
+
+    expect(data.success).toBe(true);
+    expect(logRouteError).toHaveBeenCalledWith(error, req);
+  });
+});

--- a/src/app/api/telegram/webhook/route.js
+++ b/src/app/api/telegram/webhook/route.js
@@ -1,0 +1,70 @@
+import { getHistory, appendHistory } from '@/lib/firestoreChatHistory';
+import geminiClient from '@/lib/geminiClient';
+import { logRouteError } from '@/lib/errorLogger';
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+
+    // Ensure we handle various kinds of updates (we only care about normal messages for now)
+    const message = body.message;
+    if (!message || !message.chat || !message.text) {
+      return Response.json({ success: true });
+    }
+
+    const chatId = message.chat.id;
+    const text = message.text;
+
+    // Strict validation against configured TELEGRAM_CHAT_ID
+    if (String(chatId) !== String(process.env.TELEGRAM_CHAT_ID)) {
+      console.warn(`[Telegram Webhook] Unauthorized chatId: ${chatId}. Ignoring.`);
+      return Response.json({ success: true });
+    }
+
+    // 1. Get History
+    const history = await getHistory(chatId);
+
+    // 2. Append User Message to History
+    await appendHistory(chatId, 'user', text);
+
+    // 3. Generate AI Response
+    const aiResponse = await geminiClient.generate({
+      prompt: text,
+      history: history,
+      systemPrompt: "You are a helpful and intelligent Telegram assistant for the Gravix system.",
+    });
+
+    // 4. Append AI Response to History
+    await appendHistory(chatId, 'model', aiResponse.text);
+
+    // 5. Send Response back to Telegram via API
+    const botToken = process.env.TELEGRAM_ASSISTANT_BOT_TOKEN || process.env.TELEGRAM_DEVOPS_BOT_TOKEN; // Fallback if needed
+    if (!botToken) {
+      throw new Error("Missing TELEGRAM_ASSISTANT_BOT_TOKEN");
+    }
+
+    const tgUrl = `https://api.telegram.org/bot${botToken}/sendMessage`;
+    const tgResponse = await fetch(tgUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text: aiResponse.text,
+      }),
+    });
+
+    if (!tgResponse.ok) {
+      const tgErrorText = await tgResponse.text();
+      throw new Error(`Telegram API Error: ${tgResponse.status} ${tgErrorText}`);
+    }
+
+    // Always return 200 OK so Telegram doesn't retry
+    return Response.json({ success: true });
+  } catch (error) {
+    await logRouteError(error, request);
+    // Still return 200 OK to Telegram to avoid infinite retries
+    return Response.json({ success: true });
+  }
+}

--- a/src/lib/firestoreChatHistory.js
+++ b/src/lib/firestoreChatHistory.js
@@ -1,0 +1,58 @@
+import { adminDb } from './firebaseAdmin';
+
+/**
+ * Retrieves the chat history for a given chat ID from the `telegram_sessions` collection.
+ *
+ * @param {string|number} chatId - The ID of the Telegram chat.
+ * @returns {Promise<Array<{role: string, content: string}>>} The chat history array.
+ */
+export async function getHistory(chatId) {
+  try {
+    const docRef = adminDb.collection('telegram_sessions').doc(String(chatId));
+    const docSnap = await docRef.get();
+
+    if (docSnap.exists) {
+      const data = docSnap.data();
+      return Array.isArray(data.history) ? data.history : [];
+    }
+
+    return [];
+  } catch (error) {
+    console.error(`[firestoreChatHistory] Error fetching history for chatId ${chatId}:`, error);
+    return [];
+  }
+}
+
+/**
+ * Appends a new message to the chat history for a given chat ID in the `telegram_sessions` collection.
+ *
+ * @param {string|number} chatId - The ID of the Telegram chat.
+ * @param {string} role - The role of the message sender ('user' or 'model').
+ * @param {string} content - The content of the message.
+ * @returns {Promise<void>}
+ */
+export async function appendHistory(chatId, role, content) {
+  try {
+    const docRef = adminDb.collection('telegram_sessions').doc(String(chatId));
+    const docSnap = await docRef.get();
+
+    let history = [];
+    if (docSnap.exists) {
+      const data = docSnap.data();
+      if (Array.isArray(data.history)) {
+        history = data.history;
+      }
+    }
+
+    history.push({ role, content });
+
+    // We only store the last 50 messages to keep document size manageable
+    if (history.length > 50) {
+      history = history.slice(history.length - 50);
+    }
+
+    await docRef.set({ history }, { merge: true });
+  } catch (error) {
+    console.error(`[firestoreChatHistory] Error appending history for chatId ${chatId}:`, error);
+  }
+}


### PR DESCRIPTION
This PR implements the requested Telegram webhook functionality. It creates a dedicated API route (`/api/telegram/webhook`) to receive webhook events from Telegram. It introduces a new helper module (`src/lib/firestoreChatHistory.js`) that interacts with the `telegram_sessions` Firestore collection to maintain a rolling conversation history (capped at 50 messages). It passes this history along with incoming user messages to `geminiClient` to get an AI response, which is then sent back to the user via the Telegram API. It also handles authorization by strictly validating the `chat_id`. A test suite using Vitest has been included, and all existing tests pass correctly.

---
*PR created automatically by Jules for task [9611612213011221671](https://jules.google.com/task/9611612213011221671) started by @JClouddd*