### PR TITLE
feat: implement Agent Spawner routing core

### DIFF
--- a/gravix-agent-engine/server.js
+++ b/gravix-agent-engine/server.js
@@ -1,0 +1,34 @@
+/**
+ * Agent Spawner routing core
+ *
+ * Dynamic model router that routes to gemini-2.5-flash for orchestration routing,
+ * and gemini-2.5-pro for heavy execution workloads to enable token arbitrage.
+ */
+
+function routeModel(complexity) {
+  const heavyWorkloads = ['high', 'pro', 'heavy', 'deep', 'complex'];
+
+  if (complexity && heavyWorkloads.includes(complexity.toLowerCase())) {
+    return 'gemini-2.5-pro';
+  }
+
+  // Default to gemini-2.5-flash for orchestration routing and token arbitrage
+  return 'gemini-2.5-flash';
+}
+
+function spawnAgent(task) {
+  const complexity = task?.complexity || 'low';
+  const assignedModel = routeModel(complexity);
+
+  return {
+    taskId: task?.id || `task-${Date.now()}`,
+    assignedModel,
+    taskData: task,
+    status: 'spawned'
+  };
+}
+
+module.exports = {
+  routeModel,
+  spawnAgent
+};


### PR DESCRIPTION
This PR introduces the Agent Spawner routing core to direct task payloads to specific AI models based on complexity. 
Tasks defined as `high`, `pro`, or similar heavy workloads are routed to `gemini-2.5-pro`, while all other tasks default to `gemini-2.5-flash` for orchestration. This fulfills the token arbitrage goals defined for the agent engine.

---
*PR created automatically by Jules for task [952810209096420593](https://jules.google.com/task/952810209096420593) started by @JClouddd*