### PR TITLE
feat: add gemini multimodal live api websocket proxy to agent engine

### DIFF
--- a/gravix-agent-engine/package.json
+++ b/gravix-agent-engine/package.json
@@ -1,0 +1,1 @@
+{"name": "gravix-agent-engine", "version": "1.0.0", "dependencies": {"ws": "^8.18.0"}}

--- a/gravix-agent-engine/websockets/gemini.js
+++ b/gravix-agent-engine/websockets/gemini.js
@@ -1,0 +1,41 @@
+const WebSocket = require('ws');
+
+function initializeGeminiSocket(url, apiKey, onMessage) {
+    const ws = new WebSocket(`${url}?key=${apiKey}`);
+
+    ws.on('open', () => {
+        console.log('Connected to Gemini Live API');
+    });
+
+    ws.on('message', (data) => {
+        if (onMessage) onMessage(data);
+    });
+
+    ws.on('error', (err) => {
+        console.error('Gemini WS Error:', err);
+    });
+
+    ws.on('close', () => {
+        console.log('Gemini WS Closed');
+    });
+
+    return ws;
+}
+
+function sendTwilioAudioToGemini(geminiWs, twilioAudioBuffer) {
+    if (geminiWs && geminiWs.readyState === WebSocket.OPEN) {
+        geminiWs.send(JSON.stringify({
+            realtimeInput: {
+                mediaChunks: [{
+                    mimeType: "audio/pcm;rate=16000",
+                    data: twilioAudioBuffer.toString('base64')
+                }]
+            }
+        }));
+    }
+}
+
+module.exports = {
+    initializeGeminiSocket,
+    sendTwilioAudioToGemini
+};


### PR DESCRIPTION
This PR introduces a WebSocket integration in `gravix-agent-engine` to proxy audio streams to the Gemini Multimodal Live API.

It creates `gravix-agent-engine/websockets/gemini.js` with functions to initialize a WebSocket connection and forward incoming Twilio base64 audio buffers formatted according to the Gemini API's expected payload structure. It also adds a `package.json` to the `gravix-agent-engine` directory to manage the required `ws` dependency.

---
*PR created automatically by Jules for task [10813357279319390229](https://jules.google.com/task/10813357279319390229) started by @JClouddd*