### PR TITLE
feat: inject Firestore snapshot backup logic into DBA profile

### DIFF
--- a/src/app/api/dba/snapshot/__tests__/route.test.js
+++ b/src/app/api/dba/snapshot/__tests__/route.test.js
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST, GET } from '../route';
+import { adminDb } from '@/lib/firebaseAdmin';
+
+vi.mock('@/lib/firebaseAdmin', () => {
+  const collectionMock = {
+    doc: vi.fn().mockReturnThis(),
+    set: vi.fn(),
+    update: vi.fn(),
+    where: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    get: vi.fn()
+  };
+  return {
+    adminDb: {
+      collection: vi.fn(() => collectionMock)
+    }
+  };
+});
+
+vi.mock('@/lib/errorLogger', () => ({
+  logRouteError: vi.fn()
+}));
+
+const mockExportDocuments = vi.fn();
+const mockOperationsGet = vi.fn();
+
+vi.mock('googleapis', () => {
+  return {
+    google: {
+      auth: {
+        GoogleAuth: class { constructor() {} }
+      },
+      firestore: vi.fn().mockImplementation(() => ({
+        projects: {
+          databases: {
+            exportDocuments: mockExportDocuments,
+            operations: {
+              get: mockOperationsGet
+            }
+          }
+        }
+      }))
+    }
+  }
+});
+
+describe('DBA Snapshot Route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('POST', () => {
+    it('creates a snapshot successfully', async () => {
+      mockExportDocuments.mockResolvedValueOnce({
+        data: { name: 'operations/test-operation-123' }
+      });
+      const collectionMock = adminDb.collection();
+      collectionMock.set.mockResolvedValueOnce({});
+
+      const request = new Request('http://localhost');
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.backupId).toMatch(/^snapshot-\d+$/);
+
+      expect(adminDb.collection).toHaveBeenCalledWith('dba_snapshots');
+      expect(collectionMock.set).toHaveBeenCalledWith(expect.objectContaining({
+        status: 'pending',
+        operationName: 'operations/test-operation-123'
+      }));
+    });
+
+    it('handles export errors safely', async () => {
+      mockExportDocuments.mockRejectedValueOnce(new Error('Export failed'));
+      const request = new Request('http://localhost');
+      const response = await POST(request);
+
+      expect(response.status).toBe(500);
+      const data = await response.json();
+      expect(data.success).toBe(false);
+      expect(data.error).toContain('Failed to trigger Firestore export');
+    });
+  });
+
+  describe('GET', () => {
+    it('verifies existing snapshot successfully and updates pending', async () => {
+      const collectionMock = adminDb.collection();
+
+      const updateMock = vi.fn();
+
+      collectionMock.get
+        .mockResolvedValueOnce({ // First get for pending
+          empty: false,
+          docs: [
+            {
+              data: () => ({ id: 'snapshot-123', status: 'pending', operationName: 'op-123' }),
+              ref: { update: updateMock }
+            }
+          ]
+        })
+        .mockResolvedValueOnce({ // Second get for completed
+          empty: false,
+          docs: [
+            {
+              data: () => ({ id: 'snapshot-123', status: 'completed' })
+            }
+          ]
+        });
+
+      mockOperationsGet.mockResolvedValueOnce({
+        data: { done: true }
+      });
+
+      const request = new Request('http://localhost');
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.hasSnapshot).toBe(true);
+
+      expect(mockOperationsGet).toHaveBeenCalledWith({ name: 'op-123' });
+      expect(updateMock).toHaveBeenCalledWith({ status: 'completed' });
+    });
+
+    it('handles empty snapshot collection', async () => {
+      const collectionMock = adminDb.collection();
+      collectionMock.get
+        .mockResolvedValueOnce({ empty: true, docs: [] }) // pending
+        .mockResolvedValueOnce({ empty: true, docs: [] }); // completed
+
+      const request = new Request('http://localhost');
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.hasSnapshot).toBe(false);
+      expect(data.latestSnapshot).toBe(null);
+    });
+  });
+});

--- a/src/app/api/dba/snapshot/route.js
+++ b/src/app/api/dba/snapshot/route.js
@@ -1,0 +1,107 @@
+import { adminDb } from "@/lib/firebaseAdmin";
+import { logRouteError } from "@/lib/errorLogger";
+import { google } from 'googleapis';
+
+function getFirestoreClient() {
+  const client = new google.auth.GoogleAuth({
+    scopes: ['https://www.googleapis.com/auth/datastore', 'https://www.googleapis.com/auth/cloud-platform'],
+  });
+
+  return google.firestore({
+    version: 'v1',
+    auth: client
+  });
+}
+
+export async function POST(request) {
+  try {
+    const backupId = `snapshot-${Date.now()}`;
+    const timestamp = new Date().toISOString();
+
+    // We are going to use Firestore Admin API to trigger a real backup
+    const projectId = process.env.GOOGLE_CLOUD_PROJECT || 'antigravity-hub-jcloud';
+    const firestoreAdmin = getFirestoreClient();
+    const bucketName = process.env.FIRESTORE_BACKUP_BUCKET || `${projectId}-firestore-backups`;
+
+    let operationName = null;
+    try {
+      const response = await firestoreAdmin.projects.databases.exportDocuments({
+        name: `projects/${projectId}/databases/(default)`,
+        requestBody: {
+          outputUriPrefix: `gs://${bucketName}/${backupId}`
+        }
+      });
+      operationName = response.data.name;
+    } catch (exportError) {
+      await logRouteError("dba_snapshot_trigger", exportError);
+      throw new Error(`Failed to trigger Firestore export: ${exportError.message}`);
+    }
+
+    await adminDb.collection("dba_snapshots").doc(backupId).set({
+      id: backupId,
+      timestamp,
+      status: "pending",
+      type: "full",
+      operationName
+    });
+
+    return Response.json({ success: true, backupId });
+  } catch (error) {
+    await logRouteError("dba_snapshot", error);
+    return Response.json({ success: false, error: error.message }, { status: 500 });
+  }
+}
+
+export async function GET(request) {
+  try {
+    const snapshotsRef = adminDb.collection("dba_snapshots");
+
+    // Check for pending snapshots to update their status
+    const pendingSnapshots = await snapshotsRef
+      .where("status", "==", "pending")
+      .get();
+
+    if (!pendingSnapshots.empty) {
+      const firestoreAdmin = getFirestoreClient();
+
+      for (const doc of pendingSnapshots.docs) {
+        const data = doc.data();
+        if (data.operationName) {
+          try {
+            const operationResponse = await firestoreAdmin.projects.databases.operations.get({
+              name: data.operationName
+            });
+
+            const operation = operationResponse.data;
+            if (operation.done) {
+              if (operation.error) {
+                await doc.ref.update({ status: "failed", error: operation.error });
+              } else {
+                await doc.ref.update({ status: "completed" });
+              }
+            }
+          } catch (opError) {
+             await logRouteError("dba_snapshot_operation_check", opError);
+          }
+        }
+      }
+    }
+
+    // Now get the latest completed snapshot
+    const querySnapshot = await snapshotsRef
+      .where("status", "==", "completed")
+      .orderBy("timestamp", "desc")
+      .limit(1)
+      .get();
+
+    if (querySnapshot.empty) {
+      return Response.json({ success: true, hasSnapshot: false, latestSnapshot: null });
+    }
+
+    const latestSnapshot = querySnapshot.docs[0].data();
+    return Response.json({ success: true, hasSnapshot: true, latestSnapshot });
+  } catch (error) {
+    await logRouteError("dba_snapshot_verify", error);
+    return Response.json({ success: false, error: error.message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
Inject Firestore snapshot-backup logic into the DBA Agent profile via `src/app/api/dba/snapshot/route.js`. The POST method triggers a Firestore backup using the googleapis package and the GET method allows verifying snapshot completion prior to execution. Included comprehensive Vitest tests.

---
*PR created automatically by Jules for task [7821443017755187230](https://jules.google.com/task/7821443017755187230) started by @JClouddd*