### PR TITLE
feat: proxy telegram webhook to orchestrator and handle Jules CI alerts

### DIFF
--- a/__tests__/api/telegram/webhook.test.js
+++ b/__tests__/api/telegram/webhook.test.js
@@ -1,21 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '@/app/api/telegram/webhook/route';
-import { getHistory, appendHistory } from '@/lib/firestoreChatHistory';
-import geminiClient from '@/lib/geminiClient';
 import { logRouteError } from '@/lib/errorLogger';
 
 // Mock dependencies
-vi.mock('@/lib/firestoreChatHistory', () => ({
-  getHistory: vi.fn(),
-  appendHistory: vi.fn(),
-}));
-
-vi.mock('@/lib/geminiClient', () => ({
-  default: {
-    generate: vi.fn(),
-  },
-}));
-
 vi.mock('@/lib/errorLogger', () => ({
   logRouteError: vi.fn(),
 }));
@@ -27,27 +14,27 @@ describe('Telegram Webhook Route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.TELEGRAM_CHAT_ID = '123456789';
-    process.env.TELEGRAM_ASSISTANT_BOT_TOKEN = 'test-bot-token';
+    process.env.TELEGRAM_DEVOPS_BOT_TOKEN = 'test-devops-token';
+    process.env.NEXT_PUBLIC_BASE_URL = 'http://localhost:3000';
   });
 
-  const createRequest = (body) => {
+  const createRequest = (body, url = 'http://localhost:3000/api/telegram/webhook') => {
     return {
       json: async () => body,
+      url,
     };
   };
 
-  it('should return 200 OK without processing if message is missing', async () => {
+  it('should return 200 OK without processing if message and Jules CI payload are missing', async () => {
     const req = createRequest({ update_id: 123 });
     const response = await POST(req);
     const data = await response.json();
 
     expect(data.success).toBe(true);
-    expect(getHistory).not.toHaveBeenCalled();
-    expect(geminiClient.generate).not.toHaveBeenCalled();
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it('should return 200 OK without processing if chat_id does not match', async () => {
+  it('should return 200 OK without processing if standard message chat_id does not match', async () => {
     const req = createRequest({
       message: {
         chat: { id: '999999999' },
@@ -59,27 +46,17 @@ describe('Telegram Webhook Route', () => {
     const data = await response.json();
 
     expect(data.success).toBe(true);
-    expect(getHistory).not.toHaveBeenCalled();
-    expect(geminiClient.generate).not.toHaveBeenCalled();
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it('should process the message, call Gemini, and send a response back', async () => {
+  it('should process Jules CI failed alerts and send Telegram message with retry button', async () => {
     const req = createRequest({
-      message: {
-        chat: { id: '123456789' },
-        text: 'Hello bot',
-      },
+      sessionId: 'session-123',
+      status: 'failed',
+      title: 'Fix issue 42'
     });
 
-    const mockHistory = [{ role: 'user', content: 'Hi' }];
-    getHistory.mockResolvedValue(mockHistory);
-
-    geminiClient.generate.mockResolvedValue({
-      text: 'Hello human',
-    });
-
-    fetch.mockResolvedValue({
+    fetch.mockResolvedValueOnce({
       ok: true,
     });
 
@@ -88,23 +65,44 @@ describe('Telegram Webhook Route', () => {
 
     expect(data.success).toBe(true);
 
-    expect(getHistory).toHaveBeenCalledWith('123456789');
-
-    expect(appendHistory).toHaveBeenCalledWith('123456789', 'user', 'Hello bot');
-
-    expect(geminiClient.generate).toHaveBeenCalledWith(expect.objectContaining({
-      prompt: 'Hello bot',
-      history: mockHistory,
-    }));
-
-    expect(appendHistory).toHaveBeenCalledWith('123456789', 'model', 'Hello human');
-
-    expect(fetch).toHaveBeenCalledWith('https://api.telegram.org/bottest-bot-token/sendMessage', expect.objectContaining({
+    expect(fetch).toHaveBeenCalledWith('https://api.telegram.org/bottest-devops-token/sendMessage', expect.objectContaining({
       method: 'POST',
       body: JSON.stringify({
         chat_id: '123456789',
-        text: 'Hello human',
+        text: '🔴 Jules Task Failed: Fix issue 42',
+        reply_markup: {
+          inline_keyboard: [
+            [{ text: 'Retry', callback_data: JSON.stringify({ action: 'retry', sessionId: 'session-123' }) }]
+          ]
+        }
       })
+    }));
+  });
+
+  it('should proxy standard messages to the Orchestrator via fetch', async () => {
+    const payload = {
+      message: {
+        chat: { id: '123456789' },
+        text: 'Hello bot',
+      },
+    };
+    const req = createRequest(payload);
+
+    fetch.mockResolvedValueOnce({
+      ok: true,
+    });
+
+    const response = await POST(req);
+    const data = await response.json();
+
+    expect(data.success).toBe(true);
+
+    expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/agents/route', expect.objectContaining({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload)
     }));
   });
 
@@ -117,7 +115,7 @@ describe('Telegram Webhook Route', () => {
     });
 
     const error = new Error('Test error');
-    getHistory.mockRejectedValue(error);
+    fetch.mockRejectedValueOnce(error);
 
     const response = await POST(req);
     const data = await response.json();

--- a/src/app/api/telegram/webhook/route.js
+++ b/src/app/api/telegram/webhook/route.js
@@ -1,19 +1,47 @@
-import { getHistory, appendHistory } from '@/lib/firestoreChatHistory';
-import geminiClient from '@/lib/geminiClient';
 import { logRouteError } from '@/lib/errorLogger';
 
 export async function POST(request) {
   try {
     const body = await request.json();
 
-    // Ensure we handle various kinds of updates (we only care about normal messages for now)
+    // ── Handle Jules CI Failed Status Alerts ──
+    if (body.sessionId && body.status === 'failed') {
+      const devopsToken = process.env.TELEGRAM_DEVOPS_BOT_TOKEN;
+      const expectedChatId = String(process.env.TELEGRAM_CHAT_ID || '').trim();
+
+      if (devopsToken && expectedChatId) {
+        const tgUrl = `https://api.telegram.org/bot${devopsToken}/sendMessage`;
+        await fetch(tgUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            chat_id: expectedChatId,
+            text: `🔴 Jules Task Failed: ${body.title || body.sessionId}`,
+            reply_markup: {
+              inline_keyboard: [
+                [
+                  {
+                    text: 'Retry',
+                    callback_data: JSON.stringify({ action: 'retry', sessionId: body.sessionId })
+                  }
+                ]
+              ]
+            }
+          }),
+        });
+      }
+      return Response.json({ success: true });
+    }
+
+    // ── Handle Standard Telegram Messages ──
     const message = body.message;
     if (!message || !message.chat || !message.text) {
       return Response.json({ success: true });
     }
 
     const chatId = message.chat.id;
-    const text = message.text;
 
     // Strict validation against configured TELEGRAM_CHAT_ID
     const expectedChatId = String(process.env.TELEGRAM_CHAT_ID || '').trim();
@@ -22,105 +50,17 @@ export async function POST(request) {
       return Response.json({ success: true });
     }
 
-    // 1. Get History
-    const history = await getHistory(chatId);
+    // Proxy the payload directly to the Cloud Run Orchestrator cluster (Agent Routing)
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://gravix--antigravity-hub-jcloud.us-east4.hosted.app';
+    const orchestratorUrl = `${baseUrl}/api/agents/route`;
 
-    // 2. Append User Message to History
-    await appendHistory(chatId, 'user', text);
-
-    const tools = [
-      {
-        name: "getJulesStatus",
-        description: "Check the status of running, queued, or recently failed Jules autonomous CI/CD pipelines.",
-        parameters: { type: "object", properties: {} }
-      },
-      {
-        name: "getSystemErrors",
-        description: "Check if there are any active runtime or pipeline errors in the Gravix backend.",
-        parameters: { type: "object", properties: {} }
-      }
-    ];
-
-    const systemPrompt = "You are Gravix Assistant, the deeply intelligent technical copilot for the Gravix Agentic OS. Use your tools natively to check internal data to answer user requests. Keep responses concise.";
-
-    // 3. Generate AI Response
-    let aiResponse = await geminiClient.generate({
-      prompt: text,
-      history: history,
-      tools: tools,
-      systemPrompt: systemPrompt
-    });
-
-    let finalAiText = "";
-
-    if (aiResponse.functionCalls && aiResponse.functionCalls.length > 0) {
-      const call = aiResponse.functionCalls[0];
-      let functionResult = {};
-
-      const { adminDb } = await import('@/lib/firebaseAdmin');
-
-      if (call.name === "getJulesStatus") {
-        const pipelines = await adminDb.collection("jules_pipelines").orderBy("createdAt", "desc").limit(5).get();
-        functionResult = { 
-          pipelines: pipelines.docs.map(d => ({ id: d.id, status: d.data().status })) 
-        };
-      } else if (call.name === "getSystemErrors") {
-        const errs = await adminDb.collection("system_errors").orderBy("timestamp", "desc").limit(5).get();
-        functionResult = { 
-          errors: errs.docs.map(d => d.data().message) 
-        };
-      } else {
-        functionResult = { error: "Unknown tool" };
-      }
-
-      const functionResponseParts = [
-        { functionResponse: { name: call.name, response: functionResult } }
-      ];
-
-      const extendedHistory = [
-        ...history,
-        { role: "user", parts: [{ text }] },
-        { role: "model", parts: [{ functionCall: call }] },
-        { role: "function", parts: functionResponseParts }
-      ];
-
-      const followupResponse = await geminiClient.generate({
-        prompt: "",
-        history: extendedHistory,
-        tools: tools,
-        systemPrompt: systemPrompt
-      });
-
-      finalAiText = followupResponse.text;
-    } else {
-      finalAiText = aiResponse.text;
-    }
-
-    // 4. Append AI Response to History
-    await appendHistory(chatId, 'model', finalAiText);
-
-    // 5. Send Response back to Telegram via API
-    const botToken = process.env.TELEGRAM_ASSISTANT_BOT_TOKEN || process.env.TELEGRAM_DEVOPS_BOT_TOKEN; // Fallback if needed
-    if (!botToken) {
-      throw new Error("Missing TELEGRAM_ASSISTANT_BOT_TOKEN");
-    }
-
-    const tgUrl = `https://api.telegram.org/bot${botToken}/sendMessage`;
-    const tgResponse = await fetch(tgUrl, {
+    await fetch(orchestratorUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        chat_id: chatId,
-        text: aiResponse.text,
-      }),
+      body: JSON.stringify(body),
     });
-
-    if (!tgResponse.ok) {
-      const tgErrorText = await tgResponse.text();
-      throw new Error(`Telegram API Error: ${tgResponse.status} ${tgErrorText}`);
-    }
 
     // Always return 200 OK so Telegram doesn't retry
     return Response.json({ success: true });


### PR DESCRIPTION
Refactored the `src/app/api/telegram/webhook/route.js` file:
- Removed local `geminiClient` generation and `firestoreChatHistory` interactions.
- Standard Telegram text messages are now proxied directly to the internal agent orchestrator (`/api/agents/route`) via a `fetch` call.
- Jules CI failed status alerts (identified by `body.sessionId` and `body.status === 'failed'`) are intercepted to send a push notification back to the DevOps Telegram chat using `TELEGRAM_DEVOPS_BOT_TOKEN`. The notification includes an inline keyboard with a `Retry` action bound to the session ID.
- Re-wrote the unit test file `__tests__/api/telegram/webhook.test.js` to assert the new fetch behaviors properly.

---
*PR created automatically by Jules for task [7443209777165789387](https://jules.google.com/task/7443209777165789387) started by @JClouddd*