### PR TITLE
ci: remove npm run build step from github actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -26,14 +26,8 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Build (Max Memory)
-        run: npm run build
-        env:
-          # Use 6GB of pure dedicated memory for the build (GitHub runners have 7GB RAM)
-          NODE_OPTIONS: "--max_old_space_size=6144"
-
   test:
-    needs: build
+    needs: lint
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Removed the `npm run build` step and `NODE_OPTIONS` environment variable from `.github/workflows/ci.yml`. Since Firebase App Hosting automatically handles the build process upon merging to `main`, this step is redundant in CI/CD. The workflow now only handles linting and testing, which will speed up execution time.

---
*PR created automatically by Jules for task [13670443345909876856](https://jules.google.com/task/13670443345909876856) started by @JClouddd*