### PR TITLE
chore: remove npm run build step from CI to save time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -26,14 +26,7 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Build (Max Memory)
-        run: npm run build
-        env:
-          # Use 6GB of pure dedicated memory for the build (GitHub runners have 7GB RAM)
-          NODE_OPTIONS: "--max_old_space_size=6144"
-
   test:
-    needs: build
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
- Removed the `build` step from `.github/workflows/ci.yml`.
- Removed `NODE_OPTIONS: "--max_old_space_size=6144"`.
- Renamed the remaining step's job to `lint` and removed `needs: build` from the `test` job.

---
*PR created automatically by Jules for task [5591242458586996258](https://jules.google.com/task/5591242458586996258) started by @JClouddd*