### PR TITLE
feat(youtube): Implement YouTube Module UI Shell and page.js routing

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,5 +1,47 @@
+"use client";
+
+import React, { useState } from "react";
 import AppShell from "@/components/AppShell";
+import YouTubeModule from "@/components/modules/YouTubeModule";
+
+const NAV_SECTIONS = [
+  { id: "youtube", name: "YouTube Factory", icon: "▶️" }
+];
 
 export default function Home() {
-  return <AppShell />;
+  const [activeModule, setActiveModule] = useState(null);
+
+  const renderModuleContent = () => {
+    switch (activeModule) {
+      case "youtube":
+        return <YouTubeModule />;
+      default:
+        return <AppShell />;
+    }
+  };
+
+  return (
+    <div style={{ display: 'flex', height: '100vh', flexDirection: 'column' }}>
+      <nav style={{ display: 'flex', gap: '1rem', padding: '1rem', borderBottom: '1px solid #333', background: 'transparent' }}>
+        {NAV_SECTIONS.map(sec => (
+          <button
+            key={sec.id}
+            onClick={() => setActiveModule(sec.id)}
+            style={{ padding: '8px 16px', cursor: 'pointer', background: '#222', color: '#fff', border: 'none', borderRadius: '4px' }}
+          >
+            {sec.icon} {sec.name}
+          </button>
+        ))}
+        <button
+          onClick={() => setActiveModule(null)}
+          style={{ padding: '8px 16px', cursor: 'pointer', background: '#222', color: '#fff', border: 'none', borderRadius: '4px' }}
+        >
+          Back to Main App
+        </button>
+      </nav>
+      <main style={{ flex: 1, overflow: 'hidden' }}>
+        {renderModuleContent()}
+      </main>
+    </div>
+  );
 }

--- a/src/components/modules/YouTubeModule.js
+++ b/src/components/modules/YouTubeModule.js
@@ -1,0 +1,42 @@
+"use client";
+
+import React from "react";
+
+export default function YouTubeModule() {
+  const columns = ["Ideation", "Scripting", "Production", "Review", "Published"];
+
+  return (
+    <div style={{ padding: "20px", height: "100%", overflowY: "auto" }}>
+      <h2 style={{ marginBottom: "20px" }}>YouTube Factory</h2>
+      <div
+        style={{
+          display: "flex",
+          gap: "20px",
+          overflowX: "auto",
+          paddingBottom: "10px",
+          height: "calc(100% - 60px)",
+        }}
+      >
+        {columns.map((col) => (
+          <div
+            key={col}
+            className="card-glass"
+            style={{
+              flex: "0 0 300px",
+              display: "flex",
+              flexDirection: "column",
+              padding: "15px",
+            }}
+          >
+            <h3 style={{ borderBottom: "1px solid #333", paddingBottom: "10px", marginBottom: "15px" }}>
+              {col}
+            </h3>
+            <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "10px" }}>
+              {/* Items will go here */}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Implemented the phase 8.1 YouTube Module UI Shell. Created the YouTubeModule with a 5-column Kanban layout. Wired it into `page.js` by adding a custom navigation bar and implementing the `NAV_SECTIONS` array and `renderModuleContent` switch statement, explicitly adhering to the restricted file scope limit. Verified with Playwright frontend screenshots.

---
*PR created automatically by Jules for task [15750373492356429029](https://jules.google.com/task/15750373492356429029) started by @JClouddd*