### PR TITLE
feat: Plaid integration link and sync routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "google-auth-library": "^9.15.1",
         "googleapis": "^171.4.0",
         "next": "16.2.4",
+        "plaid": "^42.1.0",
         "react": "19.2.4",
         "react-dom": "19.2.4"
       },
@@ -4304,8 +4305,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -4331,6 +4331,33 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -4707,7 +4734,6 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -4936,7 +4962,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -5363,7 +5388,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6254,6 +6278,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -6982,7 +7026,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -8714,7 +8757,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8724,7 +8766,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -9368,6 +9409,18 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/plaid": {
+      "version": "42.1.0",
+      "resolved": "https://registry.npmjs.org/plaid/-/plaid-42.1.0.tgz",
+      "integrity": "sha512-4aEVI7kAawVBYY2077jnADMRtaHQ7DnVpbxpsKDRavs2GOx3+HlzTLt7TS82LofcUlr7FmiK4a1KzqBM0StSmA==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.7.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/platform": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
@@ -9504,6 +9557,15 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "google-auth-library": "^9.15.1",
     "googleapis": "^171.4.0",
     "next": "16.2.4",
+    "plaid": "^42.1.0",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },

--- a/src/app/api/finance/plaid/link/route.js
+++ b/src/app/api/finance/plaid/link/route.js
@@ -1,0 +1,42 @@
+import { Configuration, PlaidApi, PlaidEnvironments } from 'plaid';
+import { logRouteError } from '@/lib/errorLogger';
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const {
+      client_user_id = 'user-id',
+      client_name = 'Gravix App',
+      products = ['auth', 'transactions'],
+      country_codes = ['US'],
+      language = 'en',
+    } = body;
+
+    const configuration = new Configuration({
+      basePath: PlaidEnvironments[process.env.PLAID_ENV || 'sandbox'],
+      baseOptions: {
+        headers: {
+          'PLAID-CLIENT-ID': process.env.PLAID_CLIENT_ID,
+          'PLAID-SECRET': process.env.PLAID_SECRET,
+        },
+      },
+    });
+
+    const client = new PlaidApi(configuration);
+
+    const response = await client.linkTokenCreate({
+      user: {
+        client_user_id,
+      },
+      client_name,
+      products,
+      country_codes,
+      language,
+    });
+
+    return Response.json(response.data);
+  } catch (error) {
+    await logRouteError('runtime', 'Plaid Link Error', error, '/api/finance/plaid/link');
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/finance/plaid/sync/route.js
+++ b/src/app/api/finance/plaid/sync/route.js
@@ -1,0 +1,32 @@
+import { Configuration, PlaidApi, PlaidEnvironments } from 'plaid';
+import { logRouteError } from '@/lib/errorLogger';
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const { access_token, cursor, count = 100 } = body;
+
+    const configuration = new Configuration({
+      basePath: PlaidEnvironments[process.env.PLAID_ENV || 'sandbox'],
+      baseOptions: {
+        headers: {
+          'PLAID-CLIENT-ID': process.env.PLAID_CLIENT_ID,
+          'PLAID-SECRET': process.env.PLAID_SECRET,
+        },
+      },
+    });
+
+    const client = new PlaidApi(configuration);
+
+    const response = await client.transactionsSync({
+      access_token,
+      cursor,
+      count,
+    });
+
+    return Response.json(response.data);
+  } catch (error) {
+    await logRouteError('runtime', 'Plaid Sync Error', error, '/api/finance/plaid/sync');
+    return Response.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
Added missing Plaid integration routes for `/api/finance/plaid/link` and `/api/finance/plaid/sync` using the plaid-node SDK, securely configured via environment variables.

---
*PR created automatically by Jules for task [1410896576182583871](https://jules.google.com/task/1410896576182583871) started by @JClouddd*