### PR TITLE
feat: support array of URLs for Discovery Engine ingestion

### DIFF
--- a/src/app/api/knowledge/__tests__/ingest.test.js
+++ b/src/app/api/knowledge/__tests__/ingest.test.js
@@ -37,7 +37,7 @@ describe('POST /api/knowledge/ingest', () => {
     const data = await response.json();
 
     expect(response.status).toBe(400);
-    expect(data.error).toBe('content is required (text, URL, or file content)');
+    expect(data.error).toBe('content or urls array is required');
   });
 
   it('processes text content and returns staging entry', async () => {

--- a/src/app/api/knowledge/ingest/route.js
+++ b/src/app/api/knowledge/ingest/route.js
@@ -2,23 +2,91 @@ import { classifyContent, processUrl, createStagingEntry } from "@/lib/knowledge
 import { adminDb } from "@/lib/firebaseAdmin";
 import { FieldValue } from "firebase-admin/firestore";
 import { logRouteError } from "@/lib/errorLogger";
+import { DocumentServiceClient } from "@google-cloud/discoveryengine";
+
+const documentClient = new DocumentServiceClient({
+  apiEndpoint: "us-discoveryengine.googleapis.com",
+});
 
 /**
  * POST /api/knowledge/ingest
  * Submit content for ingestion — processes, classifies, and stages for review.
- * Supports: text, url, youtube, file
+ * Supports: text, url, youtube, file, urls
  * Auto-detects YouTube URLs when type is "url"
  */
 export async function POST(request) {
   try {
     const body = await request.json();
-    let { content, type = "text", title = "", source = "manual", fileName = "" } = body;
+    let { content, type = "text", title = "", source = "manual", fileName = "", urls = [] } = body;
 
-    if (!content) {
+    if (!content && (!urls || urls.length === 0)) {
       return Response.json(
-        { error: "content is required (text, URL, or file content)" },
+        { error: "content or urls array is required" },
         { status: 400 }
       );
+    }
+
+    // ── Batch URLs Ingestion & Indexing ──
+    if (type === "urls" && Array.isArray(urls) && urls.length > 0) {
+      try {
+        const projectId = process.env.GOOGLE_CLOUD_PROJECT || "antigravity-hub-jcloud";
+        const location = process.env.GOOGLE_CLOUD_REGION || "us-east4";
+        const dataStoreId = process.env.VERTEX_DATASTORE_ID || "knowledge-vault";
+        const parent = `projects/${projectId}/locations/${location}/collections/default_collection/dataStores/${dataStoreId}/branches/default_branch`;
+
+        const documents = [];
+
+        for (const url of urls) {
+          try {
+             const urlObj = new URL("/api/knowledge/ingest-url", request.url);
+             const urlRes = await fetch(urlObj.toString(), {
+               method: "POST",
+               headers: { "Content-Type": "application/json" },
+               body: JSON.stringify({ url, type: "webpage" }),
+             });
+
+             if (urlRes.ok) {
+               const data = await urlRes.json();
+               const scrapedContent = data.entry?.content || data.summary || url;
+               const scrapedTitle = data.title || url;
+
+               const docId = Buffer.from(url).toString('base64').replace(/[^a-zA-Z0-9]/g, '').slice(0, 63);
+               documents.push({
+                 id: docId,
+                 jsonData: JSON.stringify({
+                   title: scrapedTitle,
+                   content: scrapedContent,
+                   url: url
+                 })
+               });
+             }
+          } catch (err) {
+             console.warn(`[knowledge/ingest] Failed to scrape ${url}`, err);
+          }
+        }
+
+        if (documents.length > 0) {
+          const importRequest = {
+            parent,
+            inlineSource: {
+              documents,
+            },
+          };
+
+          const [operation] = await documentClient.importDocuments(importRequest);
+
+          return Response.json({
+            success: true,
+            message: `Batch ingestion started for ${documents.length} URLs.`,
+            operationName: operation.name,
+          });
+        } else {
+          return Response.json({ error: "Failed to scrape any of the provided URLs." }, { status: 400 });
+        }
+      } catch (err) {
+        logRouteError("discovery", "/api/knowledge/ingest batch error", err, "/api/knowledge/ingest");
+        return Response.json({ error: "Batch URL ingestion failed: " + err.message }, { status: 500 });
+      }
     }
 
     // Auto-detect YouTube URLs

--- a/test_discovery.js
+++ b/test_discovery.js
@@ -1,0 +1,2 @@
+const { DocumentServiceClient } = require('@google-cloud/discoveryengine');
+console.log(!!DocumentServiceClient);

--- a/test_discovery_types.js
+++ b/test_discovery_types.js
@@ -1,0 +1,3 @@
+const { DocumentServiceClient } = require('@google-cloud/discoveryengine');
+const client = new DocumentServiceClient();
+console.log(Object.keys(client));

--- a/test_plan.js
+++ b/test_plan.js
@@ -1,0 +1,6 @@
+const { DocumentServiceClient } = require('@google-cloud/discoveryengine');
+async function test() {
+  const client = new DocumentServiceClient();
+  console.log('Client ready');
+}
+test();

--- a/test_proto.js
+++ b/test_proto.js
@@ -1,0 +1,2 @@
+const { protos } = require('@google-cloud/discoveryengine');
+console.log(protos.google.cloud.discoveryengine.v1.Document);


### PR DESCRIPTION
Upgrade Knowledge Engine to use Vertex AI Discovery Engine. The src/app/api/knowledge/ingest/route.js endpoint now supports an array of URLs (`urls`), scrapes them, and indexes them into the configured Datastore via `DocumentServiceClient.importDocuments`.

---
*PR created automatically by Jules for task [14192697860083832002](https://jules.google.com/task/14192697860083832002) started by @JClouddd*